### PR TITLE
Shared fields

### DIFF
--- a/code/search/SearchIndex.php
+++ b/code/search/SearchIndex.php
@@ -128,8 +128,7 @@ abstract class SearchIndex extends ViewableData {
 						$type = $singleton->castingClass($field);
 						if (!$type) $type = 'String';
 
-						if ($singleton->hasMethod("get$field")) $fieldoptions['lookup_chain'][] = array('call' => 'method', 'method' => "get$field");
-						else $fieldoptions['lookup_chain'][] = array('call' => 'property', 'property' => $field);
+						$fieldoptions['lookup_chain'][] = array('call' => 'property', 'property' => $field);
 					}
 				}
 
@@ -138,16 +137,40 @@ abstract class SearchIndex extends ViewableData {
 					$dataclasses = array_diff($dataclasses, array_values(ClassInfo::subclassesFor($dataclass)));
 					// Trim arguments off the type string
 					if (preg_match('/^(\w+)\(/', $type, $match)) $type = $match[1];
+					
 					// Get the origin
 					$origin = isset($fieldoptions['origin']) ? $fieldoptions['origin'] : $dataclass;
 
-					$found["{$origin}_{$fullfield}"] = array(
-						'name' => "{$origin}_{$fullfield}",
+					// Namespace field name to owning class by default, but allow
+					// sharing of fields across classes (assumes they have the same type)
+					$isShared = isset($extraOptions['shared']) && $extraOptions['shared'];
+					$name = $isShared ? $fullfield : "{$origin}_{$fullfield}";
+
+					if(
+						$isShared 
+						&& !$forceType
+						&& isset($found[$name])
+						&& $found[$name]['type'] != $type
+					) {
+						throw new InvalidArgumentException(sprintf(
+							'The shared field "%s" has different types in the available classes (%s: "%s", %s: "%s"), '
+							. 'which can lead to unexpected behaviour. Normalize the types, remove the "shared" flag, '
+							. 'or enforce sharing through the $forceType argument.',
+							$name,
+							$found[$name]['base'],
+							$found[$name]['type'],
+							$fieldoptions['base'],
+							$type
+						));
+					}
+					
+					$found[$name] = array(
+						'name' => $name,
 						'field' => $field,
 						'fullfield' => $fullfield,
 						'base' => $fieldoptions['base'],
-						'origin' => $origin,
-						'class' => $dataclass,
+						'origin' => $isShared ? null : $origin,
+						'class' => $isShared ? null : $dataclass,
 						'lookup_chain' => $fieldoptions['lookup_chain'],
 						'type' => $forceType ? $forceType : $type,
 						'multi_valued' => isset($fieldoptions['multi_valued']) ? true : false,

--- a/code/solr/SolrIndex.php
+++ b/code/solr/SolrIndex.php
@@ -199,10 +199,12 @@ abstract class SolrIndex extends SearchIndex {
 
 	protected function _addField($doc, $object, $field) {
 		$class = get_class($object);
-		if ($class != $field['origin'] && !is_subclass_of($class, $field['origin'])) return;
+		if (isset($field['origin']) && ($class != $field['origin'] && !is_subclass_of($class, $field['origin']))) {
+			return;
+		}
 
 		$value = $this->_getFieldValue($object, $field);
-		
+
 		$type = isset(self::$filterTypeMap[$field['type']]) ? self::$filterTypeMap[$field['type']] : self::$filterTypeMap['*'];
 
 		if (is_array($value)) foreach($value as $sub) {
@@ -248,7 +250,10 @@ abstract class SolrIndex extends SearchIndex {
 		// Add the user-specified fields
 
 		foreach ($this->getFieldsIterator() as $name => $field) {
-			if ($field['base'] == $base) $this->_addField($doc, $object, $field);
+			$isShared = (isset($field['extra_options']['shared']) && $field['extra_options']['shared']);
+			if ($field['base'] == $base || $isShared) {
+				$this->_addField($doc, $object, $field);
+			}
 		}
 
 		try {

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -110,14 +110,31 @@ The `SearchQuery` API has the concept of a "missing" and "present" field value f
 An index is a denormalized view of your data, so can hold data from more than one model.
 As you can only search one index at a time, all searchable classes need to be included.
 
-	// File: mysite/code/MyIndex.php:
-	<?php
+	:::php
 	class MyIndex extends SolrIndex {
 		function init() {
 			$this->addClass('Page');
 			$this->addClass('Member');
 			$this->addFulltextField('Content'); // only applies to Page class
 			$this->addFulltextField('FirstName'); // only applies to Member class
+		}
+	}
+
+Sometimes properties overlap in disparate classes, for example `Page.Title`
+and `File.Title`. By default, two separate index fields will be created.
+You can search through both by including both fields in your query,
+and connecting them through a logical `OR` criteria (syntax varies based on search engine).
+But in order to sort records from both classes by this field, it needs to be
+contained in a unified index field. You can use the `shared` flag to denote your
+preference on field storage. The engine will assume that the property is of the same
+type on all classes.
+
+	:::php
+	class MyIndex extends SolrIndex {
+		function init() {
+			$this->addClass('Page');
+			$this->addClass('File');
+			$this->addFilterField('Title', null, array('shared' => true));
 		}
 	}
 

--- a/tests/SearchUpdaterTest.php
+++ b/tests/SearchUpdaterTest.php
@@ -2,9 +2,11 @@
 
 class SearchUpdaterTest_Container extends DataObject {
 	static $db = array(
-		'Field1' => 'Varchar',
+		'Field1' => 'Varchar', 
 		'Field2' => 'Varchar',
 		'MyDate' => 'Date',
+		'SharedField1' => 'Varchar', // same field as SearchUpdaterTest_OtherContainer
+		'SharedField2' => 'Varchar', // same field as SearchUpdaterTest_OtherContainer
 	);
 
 	static $has_one = array(
@@ -13,6 +15,13 @@ class SearchUpdaterTest_Container extends DataObject {
 
 	static $has_many = array(
 		'HasManyObjects' => 'SearchUpdaterTest_HasMany'
+	);
+}
+
+class SearchUpdaterTest_OtherContainer extends DataObject {
+	static $db = array(
+		'SharedField1' => 'Varchar', // same field as SearchUpdaterTest_Container
+		'SharedField2' => 'Varchar', // same field as SearchUpdaterTest_Container
 	);
 }
 

--- a/tests/SolrIndexTest.php
+++ b/tests/SolrIndexTest.php
@@ -92,6 +92,16 @@ class SolrIndexTest extends SapphireTest {
 		$this->assertEquals('destField', $lastDef['dest']);
 	}
 
+	function testSharedField() {
+		$index = new SolrIndexTest_FakeIndex();		
+		$defs = simplexml_load_string('<fields>' . $index->getFieldDefinitions() . '</fields>');
+		$this->assertTrue((bool)$defs->xpath('field[@name="SearchUpdaterTest_Container_SharedField1"]'));
+		$this->assertTrue((bool)$defs->xpath('field[@name="SearchUpdaterTest_OtherContainer_SharedField1"]'));
+		$this->assertFalse((bool)$defs->xpath('field[@name="SearchUpdaterTest_Container_SharedField2"]'));
+		$this->assertFalse((bool)$defs->xpath('field[@name="SearchUpdaterTest_OtherContainer_SharedField2"]'));
+		$this->assertTrue((bool)$defs->xpath('field[@name="SharedField2"]'));
+	}
+
 	protected function getServiceSpy() {
 		$serviceSpy = Phockito::spy('SolrService');
 		$fakeResponse = new Apache_Solr_Response(new Apache_Solr_HttpTransport_Response(null, null, null));
@@ -108,8 +118,11 @@ class SolrIndexTest extends SapphireTest {
 class SolrIndexTest_FakeIndex extends SolrIndex {
 	function init() {
 		$this->addClass('SearchUpdaterTest_Container');
+		$this->addClass('SearchUpdaterTest_OtherContainer');
 
 		$this->addFilterField('Field1');
+		$this->addFilterField('SharedField1');
+		$this->addFilterField('SharedField2', null, array('shared' => true));
 		$this->addFilterField('MyDate', 'Date');
 		$this->addFilterField('HasOneObject.Field1');
 		$this->addFilterField('HasManyObjects.Field1');


### PR DESCRIPTION
Its not 100% clean to map one index field to multiple classes (at least in the way the current `SearchIndex` works), but its just too common to leave up to custom implementations. In all three search project I was involved in so far we needed to do this (to combine fields from CMS and DMS). See before/after example below.
- I'm unsetting `base` and `origin` keys in case the field is shared. Can you think of any side effects from this? All tests pass.
- It's assumed that the type of all shared fields is the same (up to the developer at the moment). The last type "wins".
- Its all-or-nothing, you can't share a field on some classes, and have a separate field with the same name on another. Due to the way SS property access works, this will fail silently on unknown properties.
- I've removed the "get<fieldname>" with type "method", and simply rely on <fieldname> with the type "property". This allows for more flexible overloading, e.g. SiteTree->Content as a native property, but DMSDocument->getContent() as a getter. SS treats them the same internally.
- Haven't checked if shared fields work with relation lookup chains.

Before:

```
<?php
class PageSolrIndex extends SolrIndex {

    function init() {
        $this->addClass('Page');
        $this->addClass('DMSDocument');

        $stored = (Director::isDev()) ? 'true' : 'false';

        // Fields are available on both types
        $this->addFulltextField('Title', 'Text', array('boost' => '3',));
        // Highlighted fields need to be stored
        $this->addFulltextField('Content', 'HTMLText', array('stored' => $stored));
        $this->addFulltextField('Description', 'HTMLText', array('stored' => $stored, 'boost' => '1.25'));

        // Technically, filter and sort fields are the same in Solr/Lucene
        $this->addSortField('ViewCount');
        // Caution: Stores LastEdited for SiteTree, but LastChanged for DMSDocument (see below)
        $this->addSortField('LastEdited', 'SSDatetime');
        //$this->addSortField('Title'); 

        // Aggregate fields for spelling checks
        $this->addCopyField('SiteTree_Title', 'spellcheckData');
        $this->addCopyField('DMSDocument_Title', 'spellcheckData');
        $this->addCopyField('SiteTree_Content', 'spellcheckData');
        $this->addCopyField('DMSDocument_Content', 'spellcheckData');

        // Aggregate fields for highlighting
        $this->addCopyField('SiteTree_Title', 'highlightData', array('maxChars' => 10000));
        $this->addCopyField('DMSDocument_Title', 'highlightData', array('maxChars' => 10000));
        $this->addCopyField('SiteTree_Content', 'highlightData', array('maxChars' => 10000));
        $this->addCopyField('DMSDocument_Content', 'highlightData', array('maxChars' => 10000));

        // Don't support searching staging
        $this->excludeVariantState(array('SearchVariantVersioned' => 'Stage'));
    }

    protected function _addAs($object, $base, $options) {
        $includeSubs = $options['include_children'];

        $doc = new Apache_Solr_Document();

        // Always present fields

        $doc->setField('_documentid', $this->getDocumentID($object, $base, $includeSubs));
        $doc->setField('ID', $object->ID);
        $doc->setField('ClassName', $object->ClassName);

        foreach (SearchIntrospection::hierarchy(get_class($object), false) as $class) $doc->addField('ClassHierarchy', $class);

        // Add the user-specified fields

        foreach ($this->getFieldsIterator() as $name => $field) {
            if ($field['base'] == $base) $this->_addField($doc, $object, $field);
        }

        // CUSTOM Duplicate index combined fields ("Title" rather than "DMSDocument_Title" and "SiteTree_Title").
        // This allows us to sort on these fields without deeper architectural changes to the fulltextsearch module.
        // Note: We can't use <copyField> for this purpose because it only writes into multiValue=true
        // fields, and those can't be (reliably) sorted on.
        $this->_addField($doc, $object, $this->getCustomPropertyFieldData('Title', $object));
        $lastEditedField = ($object instanceof DMSDocument) ? 'LastChanged' : 'LastEdited';
        $this->_addField($doc, $object, $this->getCustomPropertyFieldData('LastEdited', $object, 'SSDatetime', $lastEditedField));  
        // CUSTOM END

        $this->getService()->addDocument($doc);

        return $doc;
    }

    function getFieldDefinitions() {
        $xml = parent::getFieldDefinitions();

        $stored = (Director::isDev()) ? "stored='true'" : "stored='false'";

        $xml .= "\n\n\t\t<!-- Additional custom fields for sorting, see PageSolrIndex.php -->";
        $xml .= "\n\t\t<field name='Title' type='alphaOnlySort' indexed='true' stored='true' />";
        $xml .= "\n\t\t<field name='LastEdited' type='tdate' indexed='true' stored='true' />";

        return $xml;
    }

    /**
     * Return a fake field definition (mainly to stay DRY).
     */
    protected function getCustomPropertyFieldData($name, $object, $type = null, $customProperty = null) {
        if(!$type) $type = 'Varchar';
        return array(
            'name' => $name,
            'field' => $name,
            'fullfield' => $name,
            'base' => get_class($object),
            'origin' => get_class($object),
            'class' => get_class($object),
            'lookup_chain' => array(
                array('call' => 'property', 'property' => $customProperty ? $customProperty : $name)
            ),
            'type' => $type,
            'multi_valued' => false,
            'extra_options' => array()
        );
    }
}   
```

After:

```
<?php
class PageSolrIndex extends SolrIndex {

    function init() {
        $this->addClass('Page');
        $this->addClass('DMSDocument');

        // Fields are available on both types
        $this->addFulltextField('Title', 'Text', array('boost' => '3', 'shared' => true));
        // Highlighted fields need to be stored
        $this->addFulltextField('Content', 'HTMLText', array('stored' => $stored, 'shared' => true));
        $this->addFulltextField('Description', 'HTMLText', array('stored' => $stored, 'boost' => '1.25'));

        // Technically, filter and sort fields are the same in Solr/Lucene
        $this->addSortField('ViewCount');
        $this->addSortField('LastEdited', 'SSDatetime', array('shared' => true));

        // Aggregate fields for spelling checks
        $this->addCopyField('Title', 'spellcheckData');
        $this->addCopyField('Content', 'spellcheckData');

        // Aggregate fields for highlighting
        $this->addCopyField('Title', 'highlightData', array('maxChars' => 10000));
        $this->addCopyField('Content', 'highlightData', array('maxChars' => 10000));

        // Don't support searching staging
        $this->excludeVariantState(array('SearchVariantVersioned' => 'Stage'));
    }

}   
```
