### PR TITLE
Clean up SearchQuery API (less misleading names, fluent interface)

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -2,3 +2,5 @@
 
 global $databaseConfig;
 if (isset($databaseConfig['type'])) SearchUpdater::bind_manipulation_capture();
+
+Deprecation::notification_version('1.0', 'fulltextsearch');

--- a/tests/SolrIndexTest.php
+++ b/tests/SolrIndexTest.php
@@ -54,7 +54,7 @@ class SolrIndexTest extends SapphireTest {
 		$index->setService($serviceMock);
 
 		$query = new SearchQuery();
-		$query->search(
+		$query->addSearchTerm(
 			'term', 
 			null, 
 			array('Field1' => 1.5, 'HasOneObject_Field1' => 3)


### PR DESCRIPTION
`SearchQuery->search()` is highly misleading - it implies that a search is executed,
while in fact it only adds a search term to an internal property.
This gets even more confusing since the actual method executing passing
on the search request to the backend is also called `SearchIndex->search()`.
And many implementations also create a `Page_Controller->search()` one layer further up.

Renamed other methods along the same lines, for example `start()` is a confusing
name for adding a start value for pagination, and `inClass()` implies a boolean
return while in fact its adding a filter.

Also added getters to get naming a bit more consistent (e.g. `filter()` sets `$require`).

Set the deprecation notices to 2.0, so a future release.
