### PR TITLE
Remove child process model in Solr_Reindex

### DIFF
--- a/code/search/SearchIndex.php
+++ b/code/search/SearchIndex.php
@@ -367,7 +367,7 @@ abstract class SearchIndex extends ViewableData {
 	 * @return Mixed - The value of the field, or null if we couldn't look it up for some reason
 	 */
 	protected function _getFieldValue($object, $field) {
-		set_error_handler(create_function('$no, $str', 'throw new Exception("HTML Parse Error: ".$str);'), E_ALL);
+		set_error_handler(array($this, '_handleError'), E_ALL);
 
 		try {
 			foreach ($field['lookup_chain'] as $step) {
@@ -495,6 +495,13 @@ abstract class SearchIndex extends ViewableData {
 		}
 
 		return $dirty;
+	}
+
+	/**
+	 * Handles HTML parsing errors during field value retrieval.
+	 */
+	protected function _handleError($no, $str) {
+		throw new Exception("HTML Parse Error: ".$str);
 	}
 
 	/** !! These should be implemented by the full text search engine */

--- a/code/solr/Solr.php
+++ b/code/solr/Solr.php
@@ -259,21 +259,10 @@ class Solr_Reindex extends BuildTask {
 						echo "Class: $class, total: $total";
 						echo ($statevar) ? " in state $statevar\n" : "\n";
 
-						if (strpos(PHP_OS, "WIN") !== false) $statevar = '"'.str_replace('"', '\\"', $statevar).'"';
-						else $statevar = "'".$statevar."'";
+						for ($start = 0; $start < $total; $start += $this->stat('recordsPerRequest')) {
+							echo "$start..";
 
-						for ($offset = 0; $offset < $total; $offset += $this->stat('recordsPerRequest')) {
-							echo "$offset..";
-
-							$cmd = "php $script dev/tasks/$self index=$index class=$class start=$offset variantstate=$statevar";
-
-							if($verbose) {
-								echo "\n  Running '$cmd'\n";
-								$cmd .= " verbose=1 2>&1";
-							}
-
-							$res = $verbose ? passthru($cmd) : `$cmd`;
-							if($verbose) echo "  ".preg_replace('/\r\n|\n/', '$0  ', $res)."\n";
+							$this->runFrom($instance, $class, $start, $state);
 
 							// If we're in dev mode, commit more often for fun and profit
 							if (Director::isDev()) Solr::service($index)->commit();
@@ -313,11 +302,12 @@ class Solr_Reindex extends BuildTask {
 
 			// See SearchUpdater_ObjectHandler::triggerReindex
 			$item->triggerReindex();
-
 			$item->destroy();
+			unset($item);
 		}
-
-		if($verbose) echo "Done ";
+		unset($items);
+		
+		if($verbose) echo "Done \n";
 	}
 
 }

--- a/docs/en/Solr.md
+++ b/docs/en/Solr.md
@@ -82,6 +82,8 @@ regenerate the `schema.xml`, and ask Solr to reload the configuration.
 
 ## Usage
 
+### Reindex
+
 After configuring Solr, you have the option to add your existing
 content to its indices. Run the following command:
 
@@ -105,6 +107,19 @@ You can narrow down the operation with the following options:
 Note: The Solr indexes will be stored as binary files inside your SilverStripe project. 
 You can also copy the `thirdparty/` solr directory somewhere else,
 just set the `path` value in `mysite/_config.php` to point to the new location.
+
+Since a reindex usually takes longer than execution time constraints in web requests,
+it is not recommended to run it via the web. If you don't have access to a CLI environment,
+consider using a queue instead (see "Reindex Queues" below).
+
+### Database Modifications
+
+The module adds a low-level listener to database queries to determine
+if any records need to be reindexed. A reindex is triggered "out of process"
+as part of the PHP shutdown for a specific web request, which means
+it does not impact the user experience. For example, a CMS editor
+can save a page modification, have it written to the database,
+see the result in their browser, all before the reindex kicks in.
 
 ### File-based configuration (solrconfig.xml etc)
 
@@ -344,6 +359,13 @@ Now apply the configuration:
 
 Now you can use Solr text extraction either directly through the HTTP API,
 or indirectly through the ["textextraction" module](https://github.com/silverstripe-labs/silverstripe-textextraction).
+
+### Reindex Queues
+
+Since reindex operations can be quite time intensive, large installations
+can benefit from implementing a job queue to perform these operations asynchronously.
+The module provides integration with the [queuedjobs](https://github.com/silverstripe-australia/silverstripe-queuedjobs)
+module. If the module is installed, it's automatically used through the `SearchUpdateQueuedJobProcessor`.
 
 ## Debugging
 


### PR DESCRIPTION
Ran a benchmark on PHP 5.3 with 6k pages and 20k files (around ~300MB of index size overall). Memory usage increased from 53MB to 62MB, which IMHO is an acceptable leakage. That'll leave us a lot of room until hitting common limits like 128MB
