### PR TITLE
NEW Pre-filtering of indexed record through 'list' option in addClass()

### DIFF
--- a/code/search/SearchIndex.php
+++ b/code/search/SearchIndex.php
@@ -180,7 +180,9 @@ abstract class SearchIndex extends ViewableData {
 	 *
 	 * @throws Exception
 	 * @param String $class - The class to include
-	 * @param array $options - TODO: Remove
+	 * @param array $options
+	 *  - 'include_children': TODO remove
+	 *  - 'list': A {@link DataList} to pre-filter records to be indexed
 	 */
 	public function addClass($class, $options = array()) {
 		if ($this->fulltextFields || $this->filterFields || $this->sortFields) {
@@ -191,8 +193,13 @@ abstract class SearchIndex extends ViewableData {
 			throw new InvalidArgumentException('Can\'t add classes which don\'t have data tables (no $db or $has_one set on the class)');
 		}
 
+		if(isset($options['list']) && !($options['list'] instanceof SS_List)) {
+			throw new InvalidArgumentException('The "list" option needs to be of type SS_List');
+		}
+
  		$options = array_merge(array(
-			'include_children' => true
+			'include_children' => true,
+			'list' => null
 		), $options);
 
 		$this->classes[$class] = $options;

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -125,6 +125,36 @@ As you can only search one index at a time, all searchable classes need to be in
 
 TODO
 
+## Pre-filtering Indexed Records
+
+Sometimes you only want to filter a subset of all records of a certain type,
+e.g. to avoid unnecessarily large indices, or to simplify queries by excluding
+records that should never match any query variation.
+
+Example: Add `File` records, but filter for documents only (by extension)
+
+	<?php
+	class MyIndex extends SolrIndex {
+		function init() {
+			$extCategories = File::config()->get('app_categories');
+			$filesList = File::get()->where(
+				implode(
+					' OR ', 
+					array_map(
+						function($ext) {return '"Filename" LIKE \'%.' . Convert::raw2sql($ext) . '\'';}, 
+						$extCategories['doc']
+					)
+				)
+			);
+			$this->addClass('File', array('list' => $filesList));
+			// ...
+		}
+	}
+
+Please take care when using this method for records with "variant states" such
+as the `Versioned` extension. These add filters on query creation, based on the current
+context, and need to be unset to avoid unwanted side effects.
+
 ## Weighting/Boosting Fields
 
 Results aren't all created equal. Matches in some fields are more important

--- a/tests/SolrIndexTest.php
+++ b/tests/SolrIndexTest.php
@@ -47,7 +47,7 @@ class SolrIndexTest extends SapphireTest {
 	}
 
 	function testBoost() {
-		$serviceMock = $this->getServiceMock();
+		$serviceMock = $this->getServiceSpy();
 		Phockito::when($serviceMock)->search(anything(), anything(), anything(), anything(), anything())->return($this->getFakeRawSolrResponse());
 
 		$index = new SolrIndexTest_FakeIndex();
@@ -65,7 +65,7 @@ class SolrIndexTest extends SapphireTest {
 	}
 
 	function testIndexExcludesNullValues() {
-		$serviceMock = $this->getServiceMock();
+		$serviceMock = $this->getServiceSpy();
 		$index = new SolrIndexTest_FakeIndex();
 		$index->setService($serviceMock);		
 		$obj = new SearchUpdaterTest_Container();
@@ -173,6 +173,10 @@ class SolrIndexTest extends SapphireTest {
 		$serviceSpy = Phockito::spy('Solr3Service');
 		Phockito::when($serviceSpy)->_sendRawPost()->return($this->getFakeRawSolrResponse());
 
+		Phockito::when($serviceSpy)
+			->_sendRawPost(anything(), anything(), anything(), anything())
+			->return($fakeResponse);
+		
 		return $serviceSpy;
 	}
 


### PR DESCRIPTION
We needed this as an effective way to filter indexed files. We could've done this through custom properties `(function getIsUsed() {return in_array(...);}` in addition to the more basic `ShowInSearch` flag. But it seemed wasteful to index all files, plus many Solr queries and property setups are more complex than the SS DataQuery API.

Replaces https://github.com/silverstripe-labs/silverstripe-fulltextsearch/pull/25
