### PR TITLE
Added hooks to allow existing Solr run methods to be extended

### DIFF
--- a/code/solr/Solr.php
+++ b/code/solr/Solr.php
@@ -195,6 +195,7 @@ class Solr_BuildTask extends BuildTask {
 	 * @param SS_HTTPReqest $request
 	 */
 	public function run($request) {
+		$this->extend('updateRun', $request);
 		$name = get_class($this);
 		$verbose = $request->getVar('verbose');
 
@@ -213,6 +214,7 @@ class Solr_Configure extends Solr_BuildTask {
 
 	public function run($request) {
 		parent::run($request);
+		$this->extend('updateRun', $request);
 		
 		// Find the IndexStore handler, which will handle uploading config files to Solr
 		$store = $this->getSolrConfigStore();
@@ -326,6 +328,7 @@ class Solr_Reindex extends Solr_BuildTask {
 	 */
 	public function run($request) {
 		parent::run($request);
+		$this->extend('updateRun', $request);
 		
 		// Reset state
 		$originalState = SearchVariant::current_state();

--- a/tests/SolrIndexVersionedTest.php
+++ b/tests/SolrIndexVersionedTest.php
@@ -1,7 +1,5 @@
 <?php
 
-if (class_exists('Phockito')) Phockito::include_hamcrest();
-
 class SolrIndexVersionedTest extends SapphireTest {
 	
 	protected $oldMode = null;
@@ -11,6 +9,12 @@ class SolrIndexVersionedTest extends SapphireTest {
 	protected $extraDataObjects = array(
 		'SearchVariantVersionedTest_Item'
 	);
+
+	function setUpOnce() {
+		parent::setUpOnce();
+
+		if (class_exists('Phockito')) Phockito::include_hamcrest();
+	}
 
 	public function setUp() {
 

--- a/tests/SolrReindexTest.php
+++ b/tests/SolrReindexTest.php
@@ -5,8 +5,6 @@ use Monolog\Handler\HandlerInterface;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
 
-if (class_exists('Phockito')) Phockito::include_hamcrest();
-
 class SolrReindexTest extends SapphireTest {
 
 	protected $usesDatabase = true;
@@ -28,6 +26,12 @@ class SolrReindexTest extends SapphireTest {
 	 * @var SolrService
 	 */
 	protected $service = null;
+
+	function setUpOnce() {
+		parent::setUpOnce();
+
+		if (class_exists('Phockito')) Phockito::include_hamcrest();
+	}
 
 	public function setUp() {
 		parent::setUp();


### PR DESCRIPTION
Adds a hook in the run methods of Solr_BuildTask, Solr_Configure and Solr_Reindex.

My personal reason for adding this is for better namespace support as currently a HTTP request is used to store the classes to be handled and when using namespaces this currently gets sanitised.
