### PR TITLE
FIX Return a non-zero exit code when Solr_Configure has an exception

### DIFF
--- a/code/solr/Solr.php
+++ b/code/solr/Solr.php
@@ -240,6 +240,10 @@ class Solr_Configure extends Solr_BuildTask
                     ->error("Failure: " . $e->getMessage());
             }
         }
+
+        if (isset($e)) {
+            exit(1);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes #146 