### PR TITLE
Set SearchUpdateCommitJobProcessor::$dirty_indexes default to array, not bool. Fixes #151

### DIFF
--- a/code/search/processors/SearchUpdateCommitJobProcessor.php
+++ b/code/search/processors/SearchUpdateCommitJobProcessor.php
@@ -8,7 +8,7 @@ class SearchUpdateCommitJobProcessor implements QueuedJob
 {
     /**
      * The QueuedJob queue to use when processing commits
-     * 
+     *
      * @config
      * @var int
      */
@@ -47,12 +47,12 @@ class SearchUpdateCommitJobProcessor implements QueuedJob
      *
      * @var array
      */
-    public static $dirty_indexes = true;
+    public static $dirty_indexes = array();
 
     /**
      * If solrindex::commit has already been performed, but additional commits are necessary,
      * how long do we wait before attempting to touch the index again?
-     * 
+     *
      * {@see http://stackoverflow.com/questions/7512945/how-to-fix-exceeded-limit-of-maxwarmingsearchers}
      *
      * @var int
@@ -154,7 +154,7 @@ class SearchUpdateCommitJobProcessor implements QueuedJob
             return;
         }
 
-        
+
         // If any commit has run, but some (or all) indexes are un-comitted, we must re-schedule this task.
         // This could occur if we completed a searchupdate job in a prior request, as well as in
         // the current request


### PR DESCRIPTION
Related issue:
https://github.com/silverstripe/silverstripe-fulltextsearch/issues/151

Currently in `SearchUpdateCommitJobProcessor`:
```php
/**
 * List of dirty indexes to be committed
 *
 * @var array
 */
public static $dirty_indexes = true;
```

This results in many Warning being thrown as `$dirty_indexes` is used (from what I could see) exclusively as type `array`, not `boolean`.

EG:
```
#0 in_array() expects parameter 2 to be array, boolean given:: called at [/sites/statsunleashed/releases/20170811014625/fulltextsearch/code/search/processors/SearchUpdateCommitJobProcessor.php:217]
```