### PR TITLE
Remove PHP 5.3 tests as 5.3 is now unsupported.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ env:
 
 matrix:
   include:
-    - php: 5.3
-      env: DB=PGSQL CORE_RELEASE=3.1
     - php: 5.6
       env: DB=MYSQL CORE_RELEASE=3.2
     - php: 5.6


### PR DESCRIPTION
Tests for PHP 5.3 are failing, and is no longer supported anyway.

```
5.3 is not pre-installed; installing
Downloading archive: https://s3.amazonaws.com/travis-php-archives/binaries/ubuntu/14.04/x86_64/php-5.3.tar.bz2
0.06s$ curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /
bzip2: (stdin) is not a bzip2 file.
tar: Child returned status 2
tar: Error is not recoverable: exiting now

$ phpenv global 5.3
rbenv: version `5.3' not installed
```