### PR TITLE
Adding extension hooks before and after Solr tasks

### DIFF
--- a/code/solr/Solr.php
+++ b/code/solr/Solr.php
@@ -227,6 +227,8 @@ class Solr_Configure extends Solr_BuildTask
     {
         parent::run($request);
 
+        $this->extend('updateBeforeSolrConfigureTask', $request);
+
         // Find the IndexStore handler, which will handle uploading config files to Solr
         $store = $this->getSolrConfigStore();
         $indexes = Solr::get_indexes();
@@ -244,6 +246,8 @@ class Solr_Configure extends Solr_BuildTask
         if (isset($e)) {
             exit(1);
         }
+
+        $this->extend('updateAfterSolrConfigureTask', $request);
     }
 
     /**
@@ -346,10 +350,14 @@ class Solr_Reindex extends Solr_BuildTask
     {
         parent::run($request);
 
+        $this->extend('updateBeforeSolrReindexTask', $request);
+
         // Reset state
         $originalState = SearchVariant::current_state();
         $this->doReindex($request);
         SearchVariant::activate_state($originalState);
+
+        $this->extend('updateAfterSolrReindexTask', $request);
     }
 
     /**


### PR DESCRIPTION
Adding extension hooks before and after Solr_Configure and Solr_Reindex tasks to allow other modules (e.g. Translatable) to modify filters consistently across multiple task iterations.

Addressing issue #154.