### PR TITLE
FIX: coreIsActive() failed when using a namespaced core

### DIFF
--- a/src/Solr/Services/SolrService.php
+++ b/src/Solr/Services/SolrService.php
@@ -36,8 +36,14 @@ class SolrService extends SolrService_Core
      */
     public function coreIsActive($core)
     {
+        // Request the status of the full core name
         $result = $this->coreCommand('STATUS', $core);
-        return isset($result->status->$core->uptime);
+
+        // Solr returns the core as the 'short name' of the class (e.g. Mysite\Search\SolrIndex -> SolrIndex)
+        $reflection = new \ReflectionClass($core);
+        $shortClass = $reflection->getShortName();
+
+        return isset($result->status->$shortClass->uptime);
     }
 
     /**


### PR DESCRIPTION
This fixes a bug when running Solr_Configure with a core that is already configured.

Without this fix, Solr responds with an HTTP 500, because `Solr_Configure` thinks the core isn't active, and attempts to create it (which causes Solr to respond with `Core with name 'ShortClassName' already exists`).

The issue is because Solr stores the full core name (e.g. `Mysite\Search\SolrIndex`), but references it internally and via the API via the class short name (`SolrIndex` in this example).

Note: I haven't gotten this all the way to actually search a Solr core yet, so not sure if there are other namespace issues that I've yet to run into here.