### PR TITLE
FIX Double escape namespace separators in class names when excluding fields

### DIFF
--- a/src/Solr/SolrIndex.php
+++ b/src/Solr/SolrIndex.php
@@ -941,7 +941,10 @@ abstract class SolrIndex extends SearchIndex
     {
         $fq = array();
         foreach ($searchQuery->exclude as $field => $values) {
-            $excludeq = array();
+            // Handle namespaced class names
+            $field = $this->sanitiseClassName($field);
+
+            $excludeq = [];
             $missing = false;
 
             foreach ($values as $value) {


### PR DESCRIPTION
Before:

```php
$query->exclude(SiteTree::class . '_ShowInSearch', 0);
```

Result:
```
936953 [qtp2081303229-16] ERROR org.apache.solr.core.SolrCore  – org.apache.solr.common.SolrException: undefined field SilverStripeCMSModelSiteTree_ShowInSearch
```

Fix double escapes namespace separators in PHP class names when using them in `->exclude()` keys.