### PR TITLE
FIX Double escape namespace separators in class names when boosting fields

### DIFF
--- a/src/Search/Queries/SearchQuery.php
+++ b/src/Search/Queries/SearchQuery.php
@@ -19,12 +19,12 @@ class SearchQuery extends ViewableData
 
     /** These are public, but only for index & variant access - API users should not manually access these */
 
-    public $search = array();
+    public $search = [];
 
-    public $classes = array();
+    public $classes = [];
 
-    public $require = array();
-    public $exclude = array();
+    public $require = [];
+    public $exclude = [];
 
     protected $start = 0;
     protected $limit = -1;
@@ -42,14 +42,20 @@ class SearchQuery extends ViewableData
     }
 
     /**
-     * @param  String $text Search terms. Exact format (grouping, boolean expressions, etc.) depends on the search implementation.
-     * @param  array $fields Limits the search to specific fields (using composite field names)
-     * @param  array  $boost  Map of composite field names to float values. The higher the value,
-     * the more important the field gets for relevancy.
+     * @param string $text   Search terms. Exact format (grouping, boolean expressions, etc.) depends on
+     *                       the search implementation.
+     * @param array  $fields Limits the search to specific fields (using composite field names)
+     * @param array  $boost  Map of composite field names to float values. The higher the value,
+     *                       the more important the field gets for relevancy.
      */
-    public function search($text, $fields = null, $boost = array())
+    public function search($text, $fields = null, $boost = [])
     {
-        $this->search[] = array('text' => $text, 'fields' => $fields ? (array)$fields : null, 'boost' => $boost, 'fuzzy' => false);
+        $this->search[] = [
+            'text' => $text,
+            'fields' => $fields ? (array) $fields : null,
+            'boost' => $boost,
+            'fuzzy' => false
+        ];
     }
 
     /**
@@ -57,44 +63,52 @@ class SearchQuery extends ViewableData
      * to find the searched terms. For example, a term "fishing" would also likely find results
      * containing "fish" or "fisher". Depends on search implementation.
      *
-     * @param  String $text See {@link search()}
-     * @param  array $fields See {@link search()}
-     * @param  array $boost See {@link search()}
+     * @param string $text   See {@link search()}
+     * @param array  $fields See {@link search()}
+     * @param array  $boost  See {@link search()}
      */
-    public function fuzzysearch($text, $fields = null, $boost = array())
+    public function fuzzysearch($text, $fields = null, $boost = [])
     {
-        $this->search[] = array('text' => $text, 'fields' => $fields ? (array)$fields : null, 'boost' => $boost, 'fuzzy' => true);
+        $this->search[] = [
+            'text' => $text,
+            'fields' => $fields ? (array) $fields : null,
+            'boost' => $boost,
+            'fuzzy' => true
+        ];
     }
 
     public function inClass($class, $includeSubclasses = true)
     {
-        $this->classes[] = array('class' => $class, 'includeSubclasses' => $includeSubclasses);
+        $this->classes[] = [
+            'class' => $class,
+            'includeSubclasses' => $includeSubclasses
+        ];
     }
 
     /**
      * Similar to {@link search()}, but typically used to further narrow down
      * based on other facets which don't influence the field relevancy.
      *
-     * @param  String $field Composite name of the field
-     * @param  Mixed $values Scalar value, array of values, or an instance of SearchQuery_Range
+     * @param string $field  Composite name of the field
+     * @param mixed  $values Scalar value, array of values, or an instance of SearchQuery_Range
      */
     public function filter($field, $values)
     {
-        $requires = isset($this->require[$field]) ? $this->require[$field] : array();
-        $values = is_array($values) ? $values : array($values);
+        $requires = isset($this->require[$field]) ? $this->require[$field] : [];
+        $values = is_array($values) ? $values : [$values];
         $this->require[$field] = array_merge($requires, $values);
     }
 
     /**
      * Excludes results which match these criteria, inverse of {@link filter()}.
      *
-     * @param  String $field
-     * @param  mixed $values
+     * @param string $field
+     * @param mixed $values
      */
     public function exclude($field, $values)
     {
-        $excludes = isset($this->exclude[$field]) ? $this->exclude[$field] : array();
-        $values = is_array($values) ? $values : array($values);
+        $excludes = isset($this->exclude[$field]) ? $this->exclude[$field] : [];
+        $values = is_array($values) ? $values : [$values];
         $this->exclude[$field] = array_merge($excludes, $values);
     }
 

--- a/src/Solr/SolrIndex.php
+++ b/src/Solr/SolrIndex.php
@@ -133,8 +133,8 @@ abstract class SolrIndex extends SearchIndex
      *
      * @see http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters#solr.WhitespaceTokenizerFactory
      *
-     * @param String $field
-     * @param String $type
+     * @param string $field
+     * @param string $type
      * @param Array $params Parameters for the analyzer, usually at least a "class"
      */
     public function addAnalyzer($field, $type, $params)
@@ -243,7 +243,7 @@ abstract class SolrIndex extends SearchIndex
 
     /**
      * Extract a human friendly spelling suggestion from a Solr spellcheck collation string.
-     * @param String $collation
+     * @param string $collation
      * @return String
      */
     protected function getNiceSuggestion($collation = '')
@@ -262,7 +262,7 @@ abstract class SolrIndex extends SearchIndex
      * Extract a query string from a Solr spellcheck collation string.
      * Useful for constructing 'Did you mean?' links, for example:
      * <a href="http://example.com/search?q=$SuggestionQueryString">$SuggestionNice</a>
-     * @param String $collation
+     * @param string $collation
      * @return String
      */
     protected function getSuggestionQueryString($collation = '')
@@ -387,7 +387,7 @@ abstract class SolrIndex extends SearchIndex
     }
 
     /**
-     * @param String $name
+     * @param string $name
      * @param Array $spec
      * @param Array $typeMap
      * @return String XML
@@ -428,9 +428,9 @@ abstract class SolrIndex extends SearchIndex
     /**
      * Convert definition to XML tag
      *
-     * @param String $tag
-     * @param String $attrs Map of attributes
-     * @param String $content Inner content
+     * @param string $tag
+     * @param string $attrs Map of attributes
+     * @param string $content Inner content
      * @return String XML tag
      */
     protected function toXmlTag($tag, $attrs, $content = null)
@@ -448,8 +448,8 @@ abstract class SolrIndex extends SearchIndex
     }
 
     /**
-     * @param String $source Composite field name (<class>_<fieldname>)
-     * @param String $dest
+     * @param string $source Composite field name (<class>_<fieldname>)
+     * @param string $dest
      */
     public function addCopyField($source, $dest, $extraOptions = array())
     {
@@ -881,6 +881,9 @@ abstract class SolrIndex extends SearchIndex
                 if ($fields) {
                     $searchq = array();
                     foreach ($fields as $field) {
+                        // Escape namespace separators in class names
+                        $field = $this->sanitiseClassName($field);
+
                         $boost = (isset($search['boost'][$field])) ? '^' . $search['boost'][$field] : '';
                         $searchq[] = "{$field}:".$part.$fuzzy.$boost;
                     }


### PR DESCRIPTION
Following on from #189 