### PR TITLE
NEW Add SearchVariant::withCommon to run callbacks on relevant variants rather than all

### DIFF
--- a/src/Search/Variants/SearchVariant.php
+++ b/src/Search/Variants/SearchVariant.php
@@ -170,13 +170,13 @@ abstract class SearchVariant
      * Similar to {@link SearchVariant::with}, except will only use variants that apply to at least one of the classes
      * in the input array, where {@link SearchVariant::with} will run the query on the specific class you give it.
      *
-     * @param array $classes
+     * @param string[] $classes
      * @return SearchVariant_Caller
      */
     public static function withCommon(array $classes = [])
     {
         // Allow caching
-        $cacheKey = serialize($classes);
+        $cacheKey = sha1(serialize($classes));
         if (isset(self::$call_instances[$cacheKey])) {
             return self::$call_instances[$cacheKey];
         }

--- a/tests/SolrIndexTest.php
+++ b/tests/SolrIndexTest.php
@@ -172,7 +172,7 @@ class SolrIndexTest extends SapphireTest
                 $this->equalTo([
                     'qf' => SearchUpdaterTest_Container::class . '_Field1^1.5 '
                         . SearchUpdaterTest_Container::class . '_Field2^2.1 _text',
-                    'fq' => '+(_versionedstage:"" (*:* -_versionedstage:[* TO *]))',
+                    'fq' => '',
                 ]),
                 $this->anything()
             )->willReturn($this->getFakeRawSolrResponse());


### PR DESCRIPTION
This pull request is an option for how we could address #33 - it adds a new method `SearchVariant::withCommon` which will return an array of search variants that are relevant to at least one of the classes given. SolrIndex can use this to provide either the classes in the index, or the classes specified for the query by user code.

This is different from `SearchVariant::with` which will apply all variants that are relevant to the environment if you don't provide it a specific class name (which `SolrIndex::search` does with a standard query). I believe this is what is causing #33, at least for me.

The unit test fix is actually an example of the bug, since `SearchUpdaterTest_Container` is not versioned so the versioned state is not relevant to it.