### PR TITLE
FIX permit reindexing on a Windows machine

### DIFF
--- a/src/Solr/Reindex/Handlers/SolrReindexImmediateHandler.php
+++ b/src/Solr/Reindex/Handlers/SolrReindexImmediateHandler.php
@@ -60,19 +60,21 @@ class SolrReindexImmediateHandler extends SolrReindexBase
         $group,
         $taskName
     ) {
-        // Build state
+        $indexClass = get_class($indexInstance);
+        
+        // Build script parameters
+        $indexClassEscaped = $indexClass;
         $statevar = json_encode($state);
+
         if (strpos(PHP_OS, "WIN") !== false) {
             $statevar = '"'.str_replace('"', '\\"', $statevar).'"';
         } else {
             $statevar = "'".$statevar."'";
+            $class = addslashes($class);
+            $indexClassEscaped = addslashes($indexClass);
         }
 
-        // Build script
-        $indexName = $indexInstance->getIndexName();
-        $indexClass = get_class($indexInstance);
-        $indexClassEscaped = addslashes($indexClass);
-        $class = addslashes($class);
+        // Build script line
         $frameworkPath = ModuleLoader::getModule('silverstripe/framework')->getPath();
         $scriptPath = sprintf("%s%scli-script.php", $frameworkPath, DIRECTORY_SEPARATOR);
         $scriptTask = "php {$scriptPath} dev/tasks/{$taskName}";


### PR DESCRIPTION
It appears that when executing in a Microsoft Windows environment the
default shell used in the immediate reindex handler is CMD, which has
some severely different syntax support from that of a POSIX machine (e.g.
GNU bash). This leads to errors to do with double escaping certain
parameters passed in via the CLI - culminating in an Injector error about
an non-extant class e.g. `SilverStripe\\CMS\\Model\\SiteTree` - two
slashes a namespace separator does not make!