### PR TITLE
FIX Don't assume a DataObject's table.

### DIFF
--- a/src/Search/Indexes/SearchIndex.php
+++ b/src/Search/Indexes/SearchIndex.php
@@ -282,10 +282,6 @@ abstract class SearchIndex extends ViewableData
             throw new Exception('Can\'t add class to Index after fields have already been added');
         }
 
-        if (!DataObject::getSchema()->classHasTable($class)) {
-            throw new \InvalidArgumentException('Can\'t add classes which don\'t have data tables (no $db or $has_one set on the class)');
-        }
-
         $options = array_merge(array(
             'include_children' => true
         ), $options);


### PR DESCRIPTION
Knowing if a DataObject has a table or not is irrelevant - data is queried
out and pushed into solr all the same, whether there is a join table, a
base table, or any combination with maybe a few no-tables in between.
SomeDataClass::get() will fetch all data irrelevant of tables, that's the
point of an abstraction like SilverStripe's ORM.

The index featured is a default install, where `Page` is defined as

```php
use SilverStripe\CMS\Model\SiteTree;

class Page extends SiteTree
{

}
```

and defines an index [adding only `Page::class` to it](https://github.com/dnadesign/silverstripe-elemental/blob/master/src/Search/ElementalSolrIndex.php#L20).

![capture](https://user-images.githubusercontent.com/778003/36578407-e0e2e934-18c1-11e8-8860-7484065d58a9.PNG)

Resolves #168 