### PR TITLE
FIX Reenable indexing of relationship fields

### DIFF
--- a/src/Search/Indexes/SearchIndex.php
+++ b/src/Search/Indexes/SearchIndex.php
@@ -15,6 +15,7 @@ use SilverStripe\ORM\FieldType\DBField;
 use SilverStripe\ORM\FieldType\DBString;
 use SilverStripe\ORM\Queries\SQLSelect;
 use SilverStripe\View\ViewableData;
+use SilverStripe\ORM\SS_List;
 
 /**
  * SearchIndex is the base index class. Each connector will provide a subclass of this that


### PR DESCRIPTION
In previous versions one could add e.g. a filter field for their index to
a relationship, such as 'Categories.ID' where categories is a many_many
relationship. This stopped working in the SS4 upgrade. Namespaces, whoop.

Resolves #205 