### PR TITLE
NEW Update to use proxied DB instead of self-proxied

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,5 +1,11 @@
 inherit: true
 
+build:
+  nodes:
+    analysis:
+      tests:
+        override: [php-scrutinizer-run]
+
 checks:
   php:
     code_rating: true

--- a/_config/database.yml
+++ b/_config/database.yml
@@ -1,32 +1,6 @@
 ---
-Name: fulltextsearchmysql
-After:
-  - 'databaseconnectors'
+Name: fulltextsearchproxydb
 ---
-SilverStripe\Core\Injector\Injector:
-  MySQLDatabase:
-    class: SilverStripe\FullTextSearch\Search\Captures\SearchManipulateCapture_MySQLDatabase
-  MySQLPDODatabase:
-    class: SilverStripe\FullTextSearch\Search\Captures\SearchManipulateCapture_MySQLDatabase
-
----
-Name: fulltextsearchpostgresql
-After:
-  - 'postgresqlconnectors'
----
-SilverStripe\Core\Injector\Injector:
-  PostgrePDODatabase:
-    class: SilverStripe\FullTextSearch\Search\Captures\SearchManipulateCapture_PostgreSQLDatabase
-  PostgreSQLDatabase:
-    class: SilverStripe\FullTextSearch\Search\Captures\SearchManipulateCapture_PostgreSQLDatabase
-
----
-Name: fulltextsearchsqlite
-After:
-  - 'sqlite3connectors'
----
-SilverStripe\Core\Injector\Injector:
-  SQLite3PDODatabase:
-    class: SilverStripe\FullTextSearch\Search\Captures\SearchManipulateCapture_SQLite3Database
-  SQLite3Database:
-    class: SilverStripe\FullTextSearch\Search\Captures\SearchManipulateCapture_SQLite3Database
+TractorCow\SilverStripeProxyDB\ProxyDBFactory:
+  extensions:
+    - SilverStripe\FullTextSearch\Search\Extensions\ProxyDBExtension

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "silverstripe/framework": "^4.0",
         "monolog/monolog": "~1.15",
         "ptcinc/solr-php-client": "^1.0",
-        "symfony/process": "^3.2"
+        "symfony/process": "^3.2",
+        "tractorcow/silverstripe-proxy-db" : "~0.1"
     },
     "require-dev": {
         "silverstripe/cms": "^4.0",

--- a/src/Search/Captures/SearchManipulateCapture_MySQLDatabase.php
+++ b/src/Search/Captures/SearchManipulateCapture_MySQLDatabase.php
@@ -5,6 +5,10 @@ namespace SilverStripe\FullTextSearch\Search\Captures;
 use SilverStripe\ORM\Connect\MySQLDatabase;
 use SilverStripe\FullTextSearch\Search\Updaters\SearchUpdater;
 
+/**
+ * @deprecated 3.1...4.0 Please use tractorcow/silverstripe-proxy-db to proxy the database connector instead
+ */
+
 class SearchManipulateCapture_MySQLDatabase extends MySQLDatabase
 {
 

--- a/src/Search/Captures/SearchManipulateCapture_PostgreSQLDatabase.php
+++ b/src/Search/Captures/SearchManipulateCapture_PostgreSQLDatabase.php
@@ -9,6 +9,10 @@ if (!class_exists(PostgreSQLDatabase::class)) {
     return;
 }
 
+/**
+ * @deprecated 3.1...4.0 Please use tractorcow/silverstripe-proxy-db to proxy the database connector instead
+ */
+
 class SearchManipulateCapture_PostgreSQLDatabase extends PostgreSQLDatabase
 {
     public $isManipulationCapture = true;

--- a/src/Search/Captures/SearchManipulateCapture_SQLite3Database.php
+++ b/src/Search/Captures/SearchManipulateCapture_SQLite3Database.php
@@ -9,6 +9,10 @@ if (!class_exists(SQLite3Database::class)) {
     return;
 }
 
+/**
+ * @deprecated 3.1...4.0 Please use tractorcow/silverstripe-proxy-db to proxy the database connector instead
+ */
+
 class SearchManipulateCapture_SQLite3Database extends SQLite3Database
 {
 

--- a/src/Search/Extensions/ProxyDBExtension.php
+++ b/src/Search/Extensions/ProxyDBExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverStripe\FullTextSearch\Search\Extensions;
+
+use SilverStripe\Core\Extension;
+use TractorCow\ClassProxy\Generators\ProxyGenerator;
+use SilverStripe\FullTextSearch\Search\Updaters\SearchUpdater;
+
+class ProxyDBExtension extends Extension
+{
+    public function updateProxy(ProxyGenerator &$proxy)
+    {
+        $proxy = $proxy->addMethod('manipulate', function ($args, $next) {
+            $manipulation = $args[0];
+            SearchUpdater::handle_manipulation($manipulation);
+            return $next(...$args);
+        });
+    }
+}

--- a/src/Search/Extensions/ProxyDBExtension.php
+++ b/src/Search/Extensions/ProxyDBExtension.php
@@ -7,9 +7,6 @@ use TractorCow\ClassProxy\Generators\ProxyGenerator;
 use SilverStripe\FullTextSearch\Search\Updaters\SearchUpdater;
 
 /**
- * Class ProxyDBExtension
- * @package SilverStripe\FullTextSearch\Search\Extensions
- *
  * This database connector proxy will allow {@link SearchUpdater::handle_manipulation} to monitor database schema
  * changes that may need to be propagated through to search indexes.
  *

--- a/src/Search/Extensions/ProxyDBExtension.php
+++ b/src/Search/Extensions/ProxyDBExtension.php
@@ -6,8 +6,21 @@ use SilverStripe\Core\Extension;
 use TractorCow\ClassProxy\Generators\ProxyGenerator;
 use SilverStripe\FullTextSearch\Search\Updaters\SearchUpdater;
 
+/**
+ * Class ProxyDBExtension
+ * @package SilverStripe\FullTextSearch\Search\Extensions
+ *
+ * This database connector proxy will allow {@link SearchUpdater::handle_manipulation} to monitor database schema
+ * changes that may need to be propagated through to search indexes.
+ *
+ */
 class ProxyDBExtension extends Extension
 {
+    /**
+     * @param ProxyGenerator $proxy
+     *
+     * Ensure the search index is kept up to date by monitoring SilverStripe database manipulations
+     */
     public function updateProxy(ProxyGenerator &$proxy)
     {
         $proxy = $proxy->addMethod('manipulate', function ($args, $next) {

--- a/src/Search/Updaters/SearchUpdater.php
+++ b/src/Search/Updaters/SearchUpdater.php
@@ -42,7 +42,7 @@ class SearchUpdater
     public static $processor = null;
 
     /**
-     * Called by the SearchManiplateCapture database adapter with every manipulation made against the database.
+     * Called by the ProxyDBExtension database connector with every manipulation made against the database.
      *
      * Check every index to see what objects need re-inserting into what indexes to keep the index fresh,
      * but doesn't actually do it yet.


### PR DESCRIPTION
This PR makes use of Damian's proxy module https://github.com/tractorcow/silverstripe-proxy-db, which allows the registration of a shared proxy database that multiple modules can decorate.

It fixes #201. 

**Important**: It appears that proxydb can't be used with _any_ other database proxy. This means it relies on https://github.com/silverstripe/silverstripe-auditor/issues/16 being resolved. It currently works with the changes made in https://github.com/lekoala/silverstripe-debugbar/commit/b56a8ed22fa83478246c77522786ff55841d3d52.

Deprecation notices were added in the expectation to introduce these changes in  3.1.0