### PR TITLE
clean up SearchQuery API

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,0 +1,5 @@
+<?php
+
+use SilverStripe\Dev\Deprecation;
+
+Deprecation::notification_version('3.0', 'silverstripe/fulltextsearch');

--- a/docs/en/Solr.md
+++ b/docs/en/Solr.md
@@ -262,13 +262,13 @@ use SilverStripe\FullTextSearch\Search\Queries;
 
 $index = new MyIndex();
 $query = new SearchQuery();
-$query->search('My Term');
+$query->addSearchTerm('My Term');
 $params = [
     'spellcheck' => 'true',
     'spellcheck.collate' => 'true',
 ];
 $results = $index->search($query, -1, -1, $params);
-$results->spellcheck
+$results->spellcheck;
 ```
 
 The built-in `_text` data is better than nothing, but also has some problems:
@@ -337,10 +337,8 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
 
 $query = new SearchQuery();
-$query->classes = [
-    ['class' => Page::class, 'includeSubclasses' => true],
-];
-$query->search('someterms', [SiteTree::class . '_Title', SiteTree::class . '_Content']);
+$query->addClassFilter(Page::class);
+$query->addSearchTerm('someterms', [SiteTree::class . '_Title', SiteTree::class . '_Content']);
 $result = singleton(SolrSearchIndex::class)->search($query, -1, -1);
 
 // the request to Solr would be:
@@ -366,10 +364,8 @@ use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
 
 $query = new SearchQuery();
-$query->classes = [
-    ['class' => 'Page', 'includeSubclasses' => true],
-];
-$query->search('Lorem', null, [SiteTree::class . '_Content' => 2]);
+$query->addClassFilter(Page::class);
+$query->addSearchTerm('Lorem', null, [SiteTree::class . '_Content' => 2]);
 $result = singleton(SolrSearchIndex::class)->search($query, -1, -1);
 
 // the request to Solr would be:
@@ -463,7 +459,7 @@ use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
 
 $index = new MyIndex();
 $query = new SearchQuery();
-$query->search('My Term');
+$query->addSearchTerm('My Term');
 $results = $index->search($query, -1, -1, ['hl' => 'true']);
 ```
 
@@ -486,7 +482,7 @@ use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
 
 $index = new MyIndex();
 $query = new SearchQuery();
-$query->search('My Term');
+$query->addSearchTerm('My Term');
 $results = $index->search($query, -1, -1, [
     'facet' => 'true',
     'facet.field' => 'SiteTree_ClassName',
@@ -698,8 +694,8 @@ In order to query the field, reverse the search conditions and exclude the range
 
 ```php
 // Wrong: Filter will ignore all empty field values
-$myQuery->filter('fieldname', new SearchQuery_Range('*', 'somedate'));
+$myQuery->addFilter('fieldname', new SearchQuery_Range('*', 'somedate'));
 
 // Better: Exclude the opposite range
-$myQuery->exclude('fieldname', new SearchQuery_Range('somedate', '*'));
+$myQuery->addExclude('fieldname', new SearchQuery_Range('somedate', '*'));
 ```

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -85,7 +85,7 @@ Note: There's usually a connector-specific "reindex" task for this.
 use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
 
 $query = new SearchQuery();
-$query->search('My house is on fire');
+$query->addSearchTerm('My house is on fire');
 ```
 
 4). Apply that query to an index
@@ -123,7 +123,7 @@ class PageController extends ContentController
     public function search(HTTPRequest $request)
     {
         $query = new SearchQuery();
-        $query->search($request->getVar('q'));
+        $query->addSearchTerm($request->getVar('q'));
         return $this->renderWith([
             'SearchResult' => singleton(MyIndex::class)->search($query)
         ]);
@@ -178,13 +178,13 @@ Manual updates are connector specific, please check the connector docs for detai
 ## Searching Specific Fields
 
 By default, the index searches through all indexed fields.
-This can be limited by arguments to the `search()` call.
+This can be limited by arguments to the `addSearchTerm()` call.
 
 ```php
 use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
 
 $query = new SearchQuery();
-$query->search('My house is on fire', [Page::class . '_Title']);
+$query->addSearchTerm('My house is on fire', [Page::class . '_Title']);
 // No results, since we're searching in title rather than page content
 $results = singleton(MyIndex::class)->search($query);
 ```
@@ -201,9 +201,9 @@ use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
 use SilverStripe\FullTextSearch\Search\Queries\SearchQuery_Range;
 
 $query = new SearchQuery();
-$query->search('My house is on fire');
+$query->addSearchTerm('My house is on fire');
 // Only include documents edited in 2011 or earlier
-$query->filter(Page::class . '_LastEdited', new SearchQuery_Range(null, '2011-12-31T23:59:59Z'));
+$query->addFilter(Page::class . '_LastEdited', new SearchQuery_Range(null, '2011-12-31T23:59:59Z'));
 $results = singleton(MyIndex::class)->search($query);
 ```
 
@@ -220,9 +220,9 @@ The `SearchQuery` API has the concept of a "missing" and "present" field value f
 use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
 
 $query = new SearchQuery();
-$query->search('My house is on fire');
+$query->addSearchTerm('My house is on fire');
 // Needs a value, although it can be false
-$query->filter(Page::class . '_ShowInMenus', SearchQuery::$present);
+$query->addFilter(Page::class . '_ShowInMenus', SearchQuery::$present);
 $results = singleton(MyIndex::class)->search($query);
 ```
 
@@ -300,7 +300,7 @@ Example:
 use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
 
 $query = new SearchQuery();
-$query->search(
+$query->addSearchTerm(
     'My house is on fire',
     null,
     [

--- a/src/Search/Queries/SearchQuery_Range.php
+++ b/src/Search/Queries/SearchQuery_Range.php
@@ -2,6 +2,8 @@
 
 namespace SilverStripe\FullTextSearch\Search\Queries;
 
+use SilverStripe\Dev\Deprecation;
+
 /**
  * Create one of these and pass as one of the values in filter or exclude to filter or exclude by a (possibly
  * open ended) range
@@ -17,18 +19,40 @@ class SearchQuery_Range
         $this->end = $end;
     }
 
-    public function start($start)
+    public function setStart($start)
     {
         $this->start = $start;
+        return $this;
     }
 
-    public function end($end)
+    public function setEnd($end)
     {
         $this->end = $end;
+        return $this;
     }
 
-    public function isfiltered()
+    public function isFiltered()
     {
         return $this->start !== null || $this->end !== null;
+    }
+
+    /**
+     * @deprecated
+     * @codeCoverageIgnore
+     */
+    public function start($start)
+    {
+        Deprecation::notice('4.0', 'Use setStart() instead');
+        return $this->setStart($start);
+    }
+
+    /**
+     * @deprecated
+     * @codeCoverageIgnore
+     */
+    public function end($end)
+    {
+        Deprecation::notice('4.0', 'Use setEnd() instead');
+        return $this->setEnd($end);
     }
 }

--- a/src/Search/Variants/SearchVariant.php
+++ b/src/Search/Variants/SearchVariant.php
@@ -5,6 +5,7 @@ namespace SilverStripe\FullTextSearch\Search\Variants;
 use ReflectionClass;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\FullTextSearch\Search\Indexes\SearchIndex;
 use SilverStripe\FullTextSearch\Utils\CombinationsArrayIterator;
 
 /**

--- a/src/Search/Variants/SearchVariantSubsites.php
+++ b/src/Search/Variants/SearchVariantSubsites.php
@@ -4,6 +4,7 @@ namespace SilverStripe\FullTextSearch\Search\Variants;
 
 use SilverStripe\Assets\File;
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\FullTextSearch\Search\Indexes\SearchIndex;
 use SilverStripe\FullTextSearch\Search\SearchIntrospection;
 use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
 use SilverStripe\ORM\Queries\SQLSelect;
@@ -100,6 +101,9 @@ class SearchVariantSubsites extends SearchVariant
      *
      * A pull request has been raised for this issue. Once accepted this forked module can be deleted and the parent
      * project should be used instead.
+     *
+     * @param SearchQuery $query
+     * @param SearchIndex $index
      */
     public function alterQuery($query, $index)
     {
@@ -108,7 +112,7 @@ class SearchVariantSubsites extends SearchVariant
         }
 
         $subsite = $this->currentState();
-        $query->filter('_subsite', [$subsite, SearchQuery::$missing]);
+        $query->addFilter('_subsite', [$subsite, SearchQuery::$missing]);
     }
 
     /**

--- a/tests/SearchVariantSubsitesTest.php
+++ b/tests/SearchVariantSubsitesTest.php
@@ -72,7 +72,7 @@ class SearchVariantSubsiteTest extends SapphireTest
 
         //apply the subsite filter on the query (for example, if it's passed into a controller and set before searching)
         //we've chosen an arbirary value of 2 here, to check if it is changed later
-        $query->filter('_subsite', 2);
+        $query->addFilter('_subsite', 2);
         $this->assertNotEmpty($query->require['_subsite']);
 
         //apply the search variant's definition and query

--- a/tests/SolrIndexTest.php
+++ b/tests/SolrIndexTest.php
@@ -141,7 +141,7 @@ class SolrIndexTest extends SapphireTest
         $index->setService($serviceMock);
 
         $query = new SearchQuery();
-        $query->search(
+        $query->addSearchTerm(
             'term',
             null,
             array('Field1' => 1.5, 'HasOneObject_Field1' => 3)
@@ -181,7 +181,7 @@ class SolrIndexTest extends SapphireTest
         $index->setService($serviceMock);
 
         $query = new SearchQuery();
-        $query->search('term');
+        $query->addSearchTerm('term');
         $index->search($query);
     }
 
@@ -218,7 +218,7 @@ class SolrIndexTest extends SapphireTest
 
         // Search without highlighting
         $query = new SearchQuery();
-        $query->search(
+        $query->addSearchTerm(
             'term',
             null,
             array('Field1' => 1.5, 'HasOneObject_Field1' => 3)
@@ -227,7 +227,7 @@ class SolrIndexTest extends SapphireTest
 
         // Search with highlighting
         $query = new SearchQuery();
-        $query->search(
+        $query->addSearchTerm(
             'term',
             null,
             array('Field1' => 1.5, 'HasOneObject_Field1' => 3)

--- a/tests/SolrReindexQueuedTest.php
+++ b/tests/SolrReindexQueuedTest.php
@@ -5,6 +5,7 @@ namespace SilverStripe\FullTextSearch\Tests;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\FullTextSearch\Solr\Services\SolrService;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DB;
 use SilverStripe\FullTextSearch\Search\FullTextSearch;


### PR DESCRIPTION
Updated port of https://github.com/silverstripe/silverstripe-fulltextsearch/pull/64/ to improve readability and usability of the `SearchQuery` API.