### PR TITLE
Replace default CMS SearchForm with Solr version

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,3 +4,6 @@ Name: fulltextsearchconfig
 SilverStripe\ORM\DataObject:
   extensions:
     - SilverStripe\FullTextSearch\Search\Extensions\SearchUpdater_ObjectHandler
+SilverStripe\CMS\Controllers\ContentController:
+  extensions:
+    - SilverStripe\FullTextSearch\Solr\Control\ContentControllerExtension

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -46,7 +46,11 @@ SilverStripe\FullTextSearch\Search\Updaters\SearchUpdater:
 
 ## Basic usage
 
-If you have the [CMS module](https://github.com/silverstripe/silverstripe-cms) installed, you will be able to simply add `$SearchForm` to your template to add a Solr search form. Default configuration is added via the [`ContentControllerExtension`](/src/Solr/Control/ContentControllerExtension.php) and replacement [`SearchForm`](/src/Solr/Forms/SearchForm.php)
+If you have the [CMS module](https://github.com/silverstripe/silverstripe-cms) installed, you will be able to simply add `$SearchForm` to your template to add a Solr search form. Default configuration is added via the [`ContentControllerExtension`](/src/Solr/Control/ContentControllerExtension.php) and alternative [`SearchForm`](/src/Solr/Forms/SearchForm.php).
+
+Ensure that you _don't_ have `SilverStripe\ORM\Search\FulltextSearchable::enable()` set in `_config.php`, as the `SearchForm` action provided by that class will conflict.
+
+You can override the default template with a new one at `templates/Layout/Page_results_solr.ss`.
 
 Otherwise, basic usage is a four step process:
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -46,7 +46,9 @@ SilverStripe\FullTextSearch\Search\Updaters\SearchUpdater:
 
 ## Basic usage
 
-Basic usage is a four step process:
+If you have the [CMS module](https://github.com/silverstripe/silverstripe-cms) installed, you will be able to simply add `$SearchForm` to your template to add a Solr search form. Default configuration is added via the [`ContentControllerExtension`](/src/Solr/Control/ContentControllerExtension.php) and replacement [`SearchForm`](/src/Solr/Forms/SearchForm.php)
+
+Otherwise, basic usage is a four step process:
 
 1). Define an index in SilverStripe (Note: The specific connector index instance - that's what defines which engine gets used)
 

--- a/src/Search/Updaters/SearchUpdater.php
+++ b/src/Search/Updaters/SearchUpdater.php
@@ -105,8 +105,8 @@ class SearchUpdater
                     'command' => $command,
                     'fields' => array()
                 );
-            } // Otherwise update the class label if it's more specific than the currently recorded one
-            elseif (is_subclass_of($class, $writes[$key]['class'])) {
+            // Otherwise update the class label if it's more specific than the currently recorded one
+            } elseif (is_subclass_of($class, $writes[$key]['class'])) {
                 $writes[$key]['class'] = $class;
             }
 

--- a/src/Solr/Control/ContentControllerExtension.php
+++ b/src/Solr/Control/ContentControllerExtension.php
@@ -55,6 +55,6 @@ class ContentControllerExtension extends Extension
             'Query' => DBField::create_field('Text', $form->getSearchQuery()),
             'Title' => _t('SilverStripe\\CMS\\Search\\SearchForm.SearchResults', 'Search Results')
         ];
-        return $this->owner->customise($data)->renderWith(['Page_results', 'Page']);
+        return $this->owner->customise($data)->renderWith(['Page_results_solr', 'Page_results', 'Page']);
     }
 }

--- a/src/Solr/Control/ContentControllerExtension.php
+++ b/src/Solr/Control/ContentControllerExtension.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SilverStripe\FullTextSearch\Solr\Control;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Extension;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\FormAction;
+use SilverStripe\Forms\TextField;
+use SilverStripe\FullTextSearch\Solr\Forms\SearchForm;
+use SilverStripe\ORM\FieldType\DBField;
+
+class ContentControllerExtension extends Extension
+{
+    private static $allowed_actions = array(
+        'SearchForm',
+        'results',
+    );
+
+    /**
+     * Site search form
+     *
+     * @return SearchForm
+     */
+    public function SearchForm()
+    {
+        $searchText =  _t('SilverStripe\\CMS\\Search\\SearchForm.SEARCH', 'Search');
+        /** @var HTTPRequest $currentRequest */
+        $currentRequest = $this->owner->getRequest();
+
+        if ($currentRequest && $currentRequest->getVar('Search')) {
+            $searchText = $currentRequest->getVar('Search');
+        }
+
+        $fields = FieldList::create(
+            TextField::create('Search', false, $searchText)
+        );
+        $actions = FieldList::create(
+            FormAction::create('results', _t('SilverStripe\\CMS\\Search\\SearchForm.GO', 'Go'))
+        );
+        return SearchForm::create($this->owner, 'SearchForm', $fields, $actions);
+    }
+
+    /**
+     * Process and render search results.
+     *
+     * @param array $data The raw request data submitted by user
+     * @param SearchForm $form The form instance that was submitted
+     * @param HTTPRequest $request Request generated for this action
+     */
+    public function results($data, $form, $request)
+    {
+        $data = [
+            'Results' => $form->getResults(),
+            'Query' => DBField::create_field('Text', $form->getSearchQuery()),
+            'Title' => _t('SilverStripe\\CMS\\Search\\SearchForm.SearchResults', 'Search Results')
+        ];
+        return $this->owner->customise($data)->renderWith(['Page_results', 'Page']);
+    }
+}

--- a/src/Solr/Forms/SearchForm.php
+++ b/src/Solr/Forms/SearchForm.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace SilverStripe\FullTextSearch\Solr\Forms;
+
+use SilverStripe\Control\RequestHandler;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\FormAction;
+use SilverStripe\Forms\TextField;
+use SilverStripe\FullTextSearch\Search\FullTextSearch;
+use SilverStripe\FullTextSearch\Search\Queries\SearchQuery;
+use SilverStripe\FullTextSearch\Solr\SolrIndex;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\DataObject;
+
+class SearchForm extends Form
+{
+    private static $casting = array(
+        'SearchQuery' => 'Text'
+    );
+
+    /**
+     * @param RequestHandler $controller
+     * @param string $name The name of the form (used in URL addressing)
+     * @param FieldList $fields Optional, defaults to a single field named "Search". Search logic needs to be customized
+     *  if fields are added to the form.
+     * @param FieldList $actions Optional, defaults to a single field named "Go".
+     */
+    public function __construct(
+        RequestHandler $controller = null,
+        $name = 'SearchForm',
+        FieldList $fields = null,
+        FieldList $actions = null
+    ) {
+        if (!$fields) {
+            $fields = FieldList::create(
+                TextField::create('Search', _t(__CLASS__.'.SEARCH', 'Search'))
+            );
+        }
+
+        if (!$actions) {
+            $actions = FieldList::create(
+                FormAction::create("results", _t(__CLASS__.'.GO', 'Go'))
+            );
+        }
+
+        parent::__construct($controller, $name, $fields, $actions);
+
+        $this->setFormMethod('get');
+
+        $this->disableSecurityToken();
+    }
+
+    /**
+     * Return dataObjectSet of the results using current request to get info from form.
+     * Simplest implementation loops over all Solr indexes
+     *
+     * @return ArrayList
+     */
+    public function getResults()
+    {
+        // Get request data from request handler
+        $request = $this->getRequestHandler()->getRequest();
+
+        $searchTerms = $request->requestVar('Search');
+        $query = SearchQuery::create()->addSearchTerm($searchTerms);
+
+        $indexes = FullTextSearch::get_indexes(SolrIndex::class);
+        $results = ArrayList::create();
+
+        /** @var SolrIndex $index */
+        foreach ($indexes as $index) {
+            $results->merge($index->search($query)->Matches);
+        }
+
+        // filter by permission
+        if ($results) {
+            /** @var DataObject $result */
+            foreach ($results as $result) {
+                if (!$result->canView()) {
+                    $results->remove($result);
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Get the search query for display in a "You searched for ..." sentence.
+     *
+     * @return string
+     */
+    public function getSearchQuery()
+    {
+        return $this->getRequestHandler()->getRequest()->requestVar('Search');
+    }
+}

--- a/templates/Layout/Page_results_solr.ss
+++ b/templates/Layout/Page_results_solr.ss
@@ -1,0 +1,56 @@
+<div id="Content" class="searchResults">
+    <h1>$Title</h1>
+
+    <% if $Query %>
+        <p class="searchQuery">You searched for &quot;{$Query}&quot;</p>
+    <% end_if %>
+
+    <% if $Results.Suggestion %>
+        <p class="spellCheck">Did you mean <a href="{$Link}SearchForm?Search=$Results.SuggestionQueryString">$Results.SuggestionNice</a>?</p>
+    <% end_if %>
+
+    <% if $Results.Matches %>
+        <ul id="SearchResults">
+            <% loop $Results.Matches %>
+                <li>
+                    <h4>
+                        <a href="$Link">
+                            <% if $MenuTitle %>
+                                $MenuTitle
+                            <% else %>
+                                $Title
+                            <% end_if %>
+                        </a>
+                    </h4>
+                    <p><% if $Abstract %>$Abstract.XML<% else %>$Content.ContextSummary<% end_if %></p>
+                    <a class="readMoreLink" href="$Link" title="Read more about &quot;{$Title}&quot;">Read more about &quot;{$Title}&quot;...</a>
+                </li>
+            <% end_loop %>
+        </ul>
+    <% else %>
+        <p>Sorry, your search query did not return any results.</p>
+    <% end_if %>
+
+    <% if $Results.Matches.MoreThanOnePage %>
+        <div id="PageNumbers">
+            <div class="pagination">
+                <% if $Results.Matches.NotFirstPage %>
+                    <a class="prev" href="$Results.Matches.PrevLink" title="View the previous page">&larr;</a>
+                <% end_if %>
+                <span>
+                    <% loop $Results.Matches.Pages %>
+                        <% if $CurrentBool %>
+                            $PageNum
+                        <% else %>
+                            <a href="$Link" title="View page number $PageNum" class="go-to-page">$PageNum</a>
+                        <% end_if %>
+                    <% end_loop %>
+                </span>
+                <% if $Results.Matches.NotLastPage %>
+                    <a class="next" href="$Results.Matches.NextLink" title="View the next page">&rarr;</a>
+                <% end_if %>
+            </div>
+            <p>Page $Results.Matches.CurrentPage of $Results.Matches.TotalPages</p>
+        </div>
+    <% end_if %>
+</div>


### PR DESCRIPTION
Assume that if we have installed the module, we want the `$SearchForm` to use Solr, not the `FulltextSearch::enable()` version.

Will add docs shortly - and this is a very basic implementation, to be used as a jumping off point mostly I think.