### PR TITLE
add quickstart script into vendor/bin

### DIFF
--- a/bin/fulltextsearch_quickstart
+++ b/bin/fulltextsearch_quickstart
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+echo "[WARNING] This is intended for development environments only."
+echo "Do NOT use in Production."
+
+echo "Installing Java SDK..."
+# Find our package manager
+if VERB="$( command -v apt-get )" 2> /dev/null; then
+   echo "Debian-based OS detected"
+   sudo apt-get install -y openjdk-8-jdk 2> /dev/null
+elif VERB="$( command -v dnf )" 2> /dev/null; then
+   echo "Modern Fedora-based OS detected"
+   sudo dnf install -y java-1.8.0-openjdk.x86_64 2> /dev/null
+elif VERB="$( command -v yum )" 2> /dev/null; then
+   echo "Fedora-based OS detected"
+   sudo yum install -y java-1.8.0-openjdk.x86_64 2> /dev/null
+else
+   echo "No valid package manager detected; try installing one of the following:"
+   echo "apt-get, dnf, yum"
+   exit 1
+fi
+
+if [ ! -d "/opt/solr" ]; then
+    printf "Installing Solr 4"
+    # Acquire and unzip solr4
+    wget http://archive.apache.org/dist/lucene/solr/4.10.4/solr-4.10.4.tgz 2> /dev/null && printf "."
+    tar -xf solr-4.10.4.tgz 2> /dev/null && printf "."
+    rm solr-4.10.4.tgz 2> /dev/null && printf "."
+
+    # Set the defaults in /opt/solr
+    sudo mv solr-4.10.4 /opt/solr 2> /dev/null && printf "."
+    mv /opt/solr/example /opt/solr/core 2> /dev/null && echo "."
+fi
+
+if [ ! -f "/etc/init.d/solr" ]; then
+    echo "Installing Solr daemon..."
+    # Set up the daemon so that solr will run on startup
+    sudo cp vendor/silverstripe/fulltextsearch/docs/examples/daemon_script /etc/init.d/solr 2> /dev/null
+    sudo chmod +x /etc/init.d/solr 2> /dev/null
+    sudo chkconfig --add solr 2> /dev/null
+fi
+
+# Get solr running
+sudo /etc/init.d/solr start 2> /dev/null
+
+# Determine application dir
+if [ -d app ]; then
+    APPDIR="app"
+elif [ -d mysite ]; then
+    APPDIR="mysite"
+else
+    echo "Can't detect application dir - skipping default index creation"
+    exit 1
+fi
+
+# Check to see if it has been configured in _config.php
+grep -iq "Solr::configure_server(" "$APPDIR/_config.php"
+if [ "$?" != 0 ]; then
+    echo "Configuring Solr in _config.php..."
+    if [ ! -f "$APPDIR/_config.php" ]; then
+        echo "<?php" > "$APPDIR/_config.php"
+        echo "" >> "$APPDIR/_config.php"
+    fi
+    echo "" >> "$APPDIR/_config.php"
+    echo "# Enable Fulltextsearch" >> "$APPDIR/_config.php"
+    echo "\\SilverStripe\\FullTextSearch\\Solr\\Solr::configure_server([" >> "$APPDIR/_config.php"
+    echo "    'indexstore' => [" >> "$APPDIR/_config.php"
+    echo "        'mode' => 'file'," >> "$APPDIR/_config.php"
+    echo "        'path' => BASE_PATH . '/.solr'" >> "$APPDIR/_config.php"
+    echo "    ]" >> "$APPDIR/_config.php"
+    echo "]);" >> "$APPDIR/_config.php"
+fi
+
+# Determine code dir
+if [ -d "$APPDIR/src" ]; then
+    CODEDIR="$APPDIR/src"
+elif [ -d "$APPDIR/code" ]; then
+    CODEDIR="$APPDIR/code"
+else
+    echo "Can't detect code dir - skipping default index creation"
+    exit 1
+fi
+
+# Create a default index
+if [ ! -f "$CODEDIR/FulltextSearch/DefaultIndex.php" ]; then
+    echo "Creating default index..."
+    mkdir -p "$CODEDIR/FulltextSearch"
+    cp vendor/silverstripe/fulltextsearch/docs/examples/default_index.php.example "$CODEDIR/FulltextSearch/DefaultIndex.php"
+fi
+
+vendor/bin/sake dev/tasks/Solr_Configure
+vendor/bin/sake dev/tasks/Solr_Reindex
+
+echo "Quickstart complete!"

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
             "SilverStripe\\FullTextSearch\\Tests\\": "tests/"
         }
     },
+    "bin": [
+        "bin/fulltextsearch_quickstart"
+    ],
     "extra": {
         "branch-alias": {
             "dev-master": "3.x-dev"

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -46,12 +46,31 @@ SilverStripe\FullTextSearch\Search\Updaters\SearchUpdater:
 
 ## Basic usage
 
+### Quick start
+
+If you are running on a Linux-based system, you can get up and running quickly with the quickstart script, like so:
+
+```bash
+composer require silverstripe/fulltextsearch && vendor/bin/fulltextsearch_quickstart
+```
+
+This will:
+
+- Install the required Java SDK (using `apt-get` or `yum`)
+- Install Solr 4
+- Set up a daemon to run Solr on startup
+- Start Solr
+- Configure Solr in your `_config.php` (and create one if you don't have one)
+- Create a DefaultIndex
+- Run a [Solr Configure](03_configuration.md#solr-configure) and a [Solr Reindex](03_configuration.md#solr-reindex)
+
 If you have the [CMS module](https://github.com/silverstripe/silverstripe-cms) installed, you will be able to simply add `$SearchForm` to your template to add a Solr search form. Default configuration is added via the [`ContentControllerExtension`](/src/Solr/Control/ContentControllerExtension.php) and alternative [`SearchForm`](/src/Solr/Forms/SearchForm.php).
 
 Ensure that you _don't_ have `SilverStripe\ORM\Search\FulltextSearchable::enable()` set in `_config.php`, as the `SearchForm` action provided by that class will conflict.
 
 You can override the default template with a new one at `templates/Layout/Page_results_solr.ss`.
 
+### "Slow" start
 Otherwise, basic usage is a four step process:
 
 1). Define an index in SilverStripe (Note: The specific connector index instance - that's what defines which engine gets used)

--- a/docs/examples/daemon_script
+++ b/docs/examples/daemon_script
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# chkconfig: 2345 20 20
+# short-description: Solr
+# description: Startup script for Apache Solr Server
+
+SOLR_DIR="/opt/solr/core"
+LOG_FILE="/var/log/solr.log"
+JAVA="/usr/bin/java -DSTOP.PORT=8079 -DSTOP.KEY=stopkey -jar start.jar"
+
+start() {
+echo -n "Starting Solr... "
+cd $SOLR_DIR
+$JAVA > $LOG_FILE 2>&1 &
+sleep 2
+RETVAL=$?
+
+    if [ $RETVAL = 0 ]
+    then
+        echo "done."
+    else
+        echo "failed. See error code for more information."
+    fi
+    return $RETVAL
+}
+
+stop() {
+echo -n "Stopping Solr... "
+pkill -f start.jar > /dev/null
+RETVAL=$?
+
+    if [ $RETVAL = 0 ]
+    then
+        echo "done."
+    else
+        echo "failed. See error code for more information."
+    fi
+    return $RETVAL
+}
+
+case "$1" in
+start)
+start
+;;
+stop)
+stop
+;;
+restart)
+stop
+start
+;;
+*)
+echo $"Usage: solr {start|stop|restart}"
+exit 3
+esac
+exit $RETVAL

--- a/docs/examples/default_index.php.example
+++ b/docs/examples/default_index.php.example
@@ -1,0 +1,19 @@
+<?php
+
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\FullTextSearch\Solr\SolrIndex;
+
+class DefaultIndex extends SolrIndex
+{
+
+    /**
+     * Called during construction, this is the method that builds the structure.
+     * Used instead of overriding __construct as we have specific execution order - code that has
+     * to be run before _and/or_ after this.
+     */
+    public function init()
+    {
+        $this->addClass(SiteTree::class);
+        $this->addAllFulltextFields();
+    }
+}


### PR DESCRIPTION
Pulled out from #215 

Simplifies installation on a (yum- , dnf- or apt-ready) dev server to be:

```bash
composer require silverstripe/fulltextsearch && vendor/bin/fulltextsearch_quickstart
```


