### PR TITLE
Add different core installer versions to Travis matrix and add own phpcs ruleset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.0.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.0
-      env: DB=PGSQL PHPUNIT_TEST=1
+      env: DB=PGSQL INSTALLER_VERSION=4.1.x-dev PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.1.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.1
-      env: DB=MYSQL PHPUNIT_TEST=1 SUBSITES=1
+      env: DB=MYSQL INSTALLER_VERSION=4.2.x-dev PHPUNIT_TEST=1 SUBSITES=1
     - php: 7.2
-      env: DB=MYSQL PHPUNIT_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.x-dev PHPUNIT_TEST=1
 
 before_script:
   - phpenv rehash
@@ -25,13 +25,13 @@ before_script:
   - composer require --no-update symbiote/silverstripe-queuedjobs ^4.0
   - if [[ $SUBSITES ]]; then composer require --no-update silverstripe/subsites 2.0.x-dev; fi
   - if [[ $DB == "PGSQL" ]]; then composer require --no-update silverstripe/postgresql 2.0.x-dev; fi
-  - composer require --no-update silverstripe/installer 4.0.x-dev
+  - composer require --no-update silverstripe/installer "$INSTALLER_VERSION"
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
-  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=vendor/silverstripe/framework/phpcs.xml.dist src tests; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs src tests; fi
 
 after_success:
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
 before_script:
   - phpenv rehash
   - phpenv config-rm xdebug.ini
+  - echo 'memory_limit=2G' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
   - composer validate
   - composer require --no-update symbiote/silverstripe-queuedjobs ^4.0

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="SilverStripe">
+    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+
+    <!-- base rules are PSR-2 -->
+    <rule ref="PSR2">
+        <!-- Current exclusions -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName"/>
+        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
+        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+    </rule>
+</ruleset>

--- a/tests/SolrReindexQueuedTest/SolrReindexQueuedTest_Service.php
+++ b/tests/SolrReindexQueuedTest/SolrReindexQueuedTest_Service.php
@@ -3,12 +3,12 @@
 namespace SilverStripe\FullTextSearch\Tests\SolrReindexQueuedTest;
 
 use SilverStripe\Dev\TestOnly;
+use Symbiote\QueuedJobs\Services\QueuedJob;
+use Symbiote\QueuedJobs\Services\QueuedJobService;
 
-if (!class_exists('Symbiote\QueuedJobs\Services\QueuedJobService')) {
+if (!class_exists(QueuedJobService::class)) {
     return;
 }
-
-use Symbiote\QueuedJobs\Services\QueuedJobService;
 
 class SolrReindexQueuedTest_Service extends QueuedJobService implements TestOnly
 {

--- a/tests/SolrReindexTest.php
+++ b/tests/SolrReindexTest.php
@@ -2,22 +2,20 @@
 
 namespace SilverStripe\FullTextSearch\Tests;
 
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\FullTextSearch\Search\FullTextSearch;
-use SilverStripe\FullTextSearch\Search\Updaters\SearchUpdater;
-use SilverStripe\FullTextSearch\Search\Variants\SearchVariant;
-use SilverStripe\FullTextSearch\Tests\SolrReindexTest\SolrReindexTest_Variant;
-use SilverStripe\FullTextSearch\Tests\SolrReindexTest\SolrReindexTest_Index;
-use SilverStripe\FullTextSearch\Tests\SolrReindexTest\SolrReindexTest_TestHandler;
-use SilverStripe\FullTextSearch\Tests\SolrReindexTest\SolrReindexTest_Item;
-use SilverStripe\FullTextSearch\Tests\SolrReindexTest\SolrReindexTest_RecordingLogger;
-use SilverStripe\FullTextSearch\Solr\Reindex\Handlers\SolrReindexHandler;
-use SilverStripe\FullTextSearch\Solr\Services\Solr4Service;
-use SilverStripe\FullTextSearch\Solr\Tasks\Solr_Reindex;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
-use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\DB;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\FullTextSearch\Search\FullTextSearch;
+use SilverStripe\FullTextSearch\Search\Variants\SearchVariant;
+use SilverStripe\FullTextSearch\Solr\Reindex\Handlers\SolrReindexHandler;
+use SilverStripe\FullTextSearch\Solr\Services\Solr4Service;
+use SilverStripe\FullTextSearch\Solr\Services\SolrService;
+use SilverStripe\FullTextSearch\Solr\Tasks\Solr_Reindex;
+use SilverStripe\FullTextSearch\Tests\SolrReindexTest\SolrReindexTest_Index;
+use SilverStripe\FullTextSearch\Tests\SolrReindexTest\SolrReindexTest_Item;
+use SilverStripe\FullTextSearch\Tests\SolrReindexTest\SolrReindexTest_RecordingLogger;
+use SilverStripe\FullTextSearch\Tests\SolrReindexTest\SolrReindexTest_TestHandler;
+use SilverStripe\FullTextSearch\Tests\SolrReindexTest\SolrReindexTest_Variant;
 
 class SolrReindexTest extends SapphireTest
 {
@@ -70,11 +68,9 @@ class SolrReindexTest extends SapphireTest
      */
     protected function createDummyData($number)
     {
-        self::resetDBSchema();
-
         // Note that we don't create any records in variant = 2, to represent a variant
         // that should be cleared without any re-indexes performed
-        foreach (array(0, 1) as $variant) {
+        foreach ([0, 1] as $variant) {
             for ($i = 1; $i <= $number; $i++) {
                 $item = new SolrReindexTest_Item();
                 $item->Variant = $variant;
@@ -97,7 +93,7 @@ class SolrReindexTest extends SapphireTest
         return $serviceMock->getMock();
     }
 
-    public function tearDown()
+    protected function tearDown()
     {
         FullTextSearch::force_index_list();
         SolrReindexTest_Variant::disable();


### PR DESCRIPTION
This will test fulltextsearch across multiple core versions in Travis, and also stops relying on the framework phpcs ruleset (added to gitattributes as export-ignore in later versions).

I'll raise a separate issue to implement further PSR-2 compliance changes.