### PR TITLE
FIX Use \Exception for catching Solr exceptions

### DIFF
--- a/src/Solr/SolrIndex.php
+++ b/src/Solr/SolrIndex.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\FullTextSearch\Solr;
 
+use Exception;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Environment;
 use SilverStripe\FulltextSearch\Search\Indexes\SearchIndex;


### PR DESCRIPTION
As titled. Existing try...catch blocks are not catching errors that are intended to be caught.