### PR TITLE
FIX Reduce log level so errors do not automatically output

### DIFF
--- a/src/Search/Indexes/SearchIndex.php
+++ b/src/Search/Indexes/SearchIndex.php
@@ -565,7 +565,7 @@ abstract class SearchIndex extends ViewableData
      */
     public static function warn($e)
     {
-        Injector::inst()->get(LoggerInterface::class)->warning($e);
+        Injector::inst()->get(LoggerInterface::class)->info($e);
     }
 
     /**


### PR DESCRIPTION
Resolves #222 

This reduces the log level. Unfortunately the method name is still `warn` which could be considered inconsistent but I didn't want to change the API.