### PR TITLE
Removing use of deprecated method

### DIFF
--- a/src/Search/Variants/SearchVariantVersioned.php
+++ b/src/Search/Variants/SearchVariantVersioned.php
@@ -53,7 +53,7 @@ class SearchVariantVersioned extends SearchVariant
 
     public function alterQuery($query, $index)
     {
-        $query->filter('_versionedstage', [
+        $query->addFilter('_versionedstage', [
             $this->currentState(),
             SearchQuery::$missing
         ]);


### PR DESCRIPTION
This is the last usage of a deprecated method left in this module. Additionally, the last across all supported modules (at least in terms of CWP) that I can seem to find.

Fixes silverstripe/cwp-recipe-search#6