### PR TITLE
Add ContentControllerExtension back

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -5,6 +5,10 @@ SilverStripe\ORM\DataObject:
   extensions:
     - SilverStripe\FullTextSearch\Search\Extensions\SearchUpdater_ObjectHandler
 
+SilverStripe\CMS\Controllers\ContentController:
+  extensions:
+    - SilverStripe\FullTextSearch\Solr\Control\ContentControllerExtension
+    
 SilverStripe\Core\Injector\Injector:
   SilverStripe\FullTextSearch\Search\Queries\SearchQuery:
     calls:


### PR DESCRIPTION
Fixes #231.

Initially added in 7b78a84 and removed in e08731d but was intended to be added back in once #216 was merged from what I can tell.