### PR TITLE
Update Process timeout via Config

### DIFF
--- a/src/Solr/Reindex/Handlers/SolrReindexImmediateHandler.php
+++ b/src/Solr/Reindex/Handlers/SolrReindexImmediateHandler.php
@@ -98,11 +98,8 @@ class SolrReindexImmediateHandler extends SolrReindexBase
         // Execute script via shell
         $process = new Process($cmd);
 
-        // Set timeout from config. Process default is 60 seconds.
-        $timeout = Config::inst()->get(static::class, 'process_timeout');
-        if ($timeout) {
-            $process->setTimeout($timeout);
-        }
+        // Set timeout from config. Process default is 60 seconds
+        $process->setTimeout($this->config()->get('process_timeout'));
 
         $process->inheritEnvironmentVariables();
         $process->run();

--- a/src/Solr/Reindex/Handlers/SolrReindexImmediateHandler.php
+++ b/src/Solr/Reindex/Handlers/SolrReindexImmediateHandler.php
@@ -97,6 +97,13 @@ class SolrReindexImmediateHandler extends SolrReindexBase
 
         // Execute script via shell
         $process = new Process($cmd);
+
+        // Set timeout from config. Process default is 60 seconds.
+        $timeout = Config::inst()->get(static::class, 'process_timeout');
+        if ($timeout) {
+            $process->setTimeout($timeout);
+        }
+
         $process->inheritEnvironmentVariables();
         $process->run();
 


### PR DESCRIPTION
Currently SolrReindexImmediateHandler will die after 60 seconds, as that is the default timeout in Symfony\Component\Process\Process. This will allow that to be overridden via Config