### PR TITLE
FIX #241 - Support numerically indexed array of classes

### DIFF
--- a/src/Search/Variants/SearchVariant.php
+++ b/src/Search/Variants/SearchVariant.php
@@ -187,8 +187,8 @@ abstract class SearchVariant
         $commonVariants = [];
         foreach ($classes as $class => $options) {
             // BC for numerically indexed list of classes
-            if (is_numeric($class) && isset($options['class'])) {
-                $class = $options['class'];
+            if (is_numeric($class) && !empty($options['class'])) {
+                $class = $options['class']; // $options['class'] is assumed to exist throughout the code base
             }
 
             // Extract relevant class options

--- a/src/Search/Variants/SearchVariant.php
+++ b/src/Search/Variants/SearchVariant.php
@@ -186,6 +186,11 @@ abstract class SearchVariant
         // Construct new array of variants applicable to at least one class in the list
         $commonVariants = [];
         foreach ($classes as $class => $options) {
+            // BC for numerically indexed list of classes
+            if (is_numeric($class) && isset($options['class'])) {
+                $class = $options['class'];
+            }
+
             // Extract relevant class options
             $includeSubclasses = isset($options['include_children']) ? $options['include_children'] : true;
 


### PR DESCRIPTION
Re-add the option to use numerically indexed arrays of classes in `withCommon` method, similar to what `with` method allowed.