### PR TITLE
Adds a 'post' option for solrconfigstore

### DIFF
--- a/src/Solr/Solr.php
+++ b/src/Solr/Solr.php
@@ -32,13 +32,19 @@ class Solr
      *
      * indexstore => an array with
      *
-     *   mode - a classname which implements SolrConfigStore, or 'file' or 'webdav'
+     *   mode - a classname which implements SolrConfigStore, or 'file', 'webdav' or 'post'
      *
-     *   When mode == SolrConfigStore_File or file (indexes should be written on a local filesystem)
+     *   When mode == SolrConfigStore_File or 'file' (indexes should be written on a local filesystem)
      *      path - The (locally accessible) path to write the index configurations to.
      *      remotepath (default: the same as indexpath) - The path that the Solr server will read the index configurations from
      *
-     *   When mode == SolrConfigStore_WebDAV or webdav (indexes should stored on a remote Solr server via webdav)
+     *   When mode == SolrConfigStore_Post or 'post' (indexes should stored on a remote Solr server via post)
+     *   This mode will require custom software on the remote solr server which handles receiving the post and
+     *   passing on that information to solr. It is up to the user of this mode to write such software.
+     *      path (default: /solrindex) - The suburl on the solr host that is set up to accept index configurations
+     *      port (default: none) - The port on the remote server which is set up to receive the post information
+     *
+     *   When mode == SolrConfigStore_WebDAV or 'webdav' (indexes should stored on a remote Solr server via webdav)
      *      auth (default: none) - A username:password pair string to use to auth against the webdav server
      *      path (default: /solrindex) - The suburl on the solr host that is set up to accept index configurations via webdav
      *      port (default: none) - The port for WebDAV if different from the Solr port

--- a/src/Solr/Stores/SolrConfigStore_Post.php
+++ b/src/Solr/Stores/SolrConfigStore_Post.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SilverStripe\FullTextSearch\Solr\Stores;
+
+use SilverStripe\FullTextSearch\Solr\Solr;
+use SilverStripe\FullTextSearch\Solr\Stores\SolrConfigStore;
+
+class SolrConfigStore_Post implements SolrConfigStore
+{
+    /**
+     * @var string
+     */
+    protected $remote = '';
+
+    /**
+     * @var string
+     */
+    protected $url = '';
+
+    /**
+     * @param array $config
+     */
+    public function __construct($config)
+    {
+        $options = Solr::solr_options();
+
+        $this->url = implode('', [
+            'http://',
+            isset($config['auth']) ? $config['auth'] . '@' : '',
+            $options['host'] . ':' . $options['port'],
+            $config['path']
+        ]);
+        $this->remote = $config['remotepath'];
+    }
+
+    /**
+     * @param string $index
+     * @param string $file
+     * @return void
+     */
+    public function uploadFile($index, $file)
+    {
+        $this->uploadString($index, basename($file), file_get_contents($file));
+    }
+
+    /**
+     *
+     * @param string $index
+     * @param string $filename
+     * @param string $string
+     * @return void
+     */
+    public function uploadString($index, $filename, $string)
+    {
+        $targetDir = "{$this->url}/config/$index";
+
+        file_get_contents($targetDir . '/' . $filename, false, stream_context_create([
+            'http' => [
+                'method' => 'POST',
+                'header' => 'Content-type: application/octet-stream',
+                'content' => (string) $string
+            ]
+        ]));
+    }
+
+    /**
+     * @param string $index
+     * @return string
+     */
+    public function instanceDir($index)
+    {
+        return $this->remote ? "{$this->remote}/$index" : $index;
+    }
+}

--- a/src/Solr/Tasks/Solr_Configure.php
+++ b/src/Solr/Tasks/Solr_Configure.php
@@ -5,6 +5,7 @@ use Exception;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\FullTextSearch\Solr\Solr;
 use SilverStripe\FullTextSearch\Solr\Stores\SolrConfigStore_File;
+use SilverStripe\FullTextSearch\Solr\Stores\SolrConfigStore_Post;
 use SilverStripe\FullTextSearch\Solr\Stores\SolrConfigStore_WebDAV;
 use SilverStripe\FullTextSearch\Solr\Stores\SolrConfigStore;
 
@@ -89,6 +90,8 @@ class Solr_Configure extends Solr_BuildTask
             return new SolrConfigStore_File($indexstore);
         } elseif ($mode == 'webdav') {
             return new SolrConfigStore_WebDAV($indexstore);
+        } elseif ($mode == 'post') {
+            return new SolrConfigStore_Post($indexstore);
         } elseif (ClassInfo::exists($mode) && ClassInfo::classImplements($mode, SolrConfigStore::class)) {
             return new $mode($indexstore);
         } else {


### PR DESCRIPTION
# What 
This copies the `CwpSolrConfigStore` ([from here](https://github.com/silverstripe/cwp-search/blob/master/src/Solr/CwpSolrConfigStore.php)) in to the fulltextsearch module. If merged that file can be removed from the cwp-search module and the mode set to 'post' in `CwpSolr.php`

# Why
The CWP solrproxy which receives the solr configuration files via POST is going to be used on SSP also. This requires the application to configure a config store which does a POST to send through the files. As this config store is not strongly tied to the CWP solr proxy, just an endpoint that requires a POST I think it is generic enough to put in this module. This will mean users of solr on SSP will not need to install CWP modules to use solr.