### PR TITLE
Disable indexing on file migration

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -13,3 +13,7 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\FullTextSearch\Search\Queries\SearchQuery:
     calls:
       - [ setHandler, [ %$SilverStripe\FullTextSearch\Search\Adapters\SolrSearchAdapter ]]
+
+SilverStripe\Dev\Tasks\MigrateFileTask:
+  extensions:
+  -  SilverStripe\FullTextSearch\Search\Extensions\DisableIndexingOnFileMigration

--- a/docs/en/01_getting_started.md
+++ b/docs/en/01_getting_started.md
@@ -39,7 +39,7 @@ configured and running) that each connector deals with itself, in a way best sui
 If you are running on a Linux-based system, you can get up and running quickly with the quickstart script, like so:
 
 ```bash
-composer require silverstripe/fulltextsearch && vendor/bin/fts_quickstart
+composer require silverstripe/fulltextsearch --prefer-source && vendor/bin/fts_quickstart
 ```
 
 This will:

--- a/src/Search/Extensions/DisableIndexingOnFileMigration.php
+++ b/src/Search/Extensions/DisableIndexingOnFileMigration.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SilverStripe\FullTextSearch\Search\Extensions;
+
+use Psr\Log\LoggerInterface;
+use SilverStripe\Core\Extension;
+use SilverStripe\FullTextSearch\Search\Updaters\SearchUpdater;
+
+/**
+ * This extension can be applied to `SilverStripe\Dev\Tasks\MigrateFileTask` to avoid constantly re-indexing files
+ * while the file migration is running.
+ */
+class DisableIndexingOnFileMigration extends Extension
+{
+    private static $dependencies = [
+        'logger' => '%$' . LoggerInterface::class . '.quiet',
+    ];
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    /**
+     * @param LoggerInterface $logger
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function preFileMigration()
+    {
+        if (SearchUpdater::config()->get('enabled')) {
+            $this->logger->info('Disabling fulltext search re-indexing for this request only');
+            SearchUpdater::config()->set('enabled', false);
+        }
+    }
+}

--- a/tests/DisableIndexingOnFileMigrationTest.php
+++ b/tests/DisableIndexingOnFileMigrationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SilverStripe\FullTextSearch\Tests\SolrReindexTest;
+
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\FullTextSearch\Search\Extensions\DisableIndexingOnFileMigration;
+use SilverStripe\FullTextSearch\Search\Updaters\SearchUpdater;
+
+/**
+ * Logger for recording messages for later retrieval
+ */
+class DisableIndexingOnFileMigrationTest extends SapphireTest
+{
+
+    public function testPreFileMigration()
+    {
+        $this->assertTrue(SearchUpdater::config()->get('enabled'));
+
+        Injector::inst()->get(DisableIndexingOnFileMigration::class)->preFileMigration();
+
+        $this->assertFalse(SearchUpdater::config()->get('enabled'));
+    }
+}


### PR DESCRIPTION
This PR disables indexing when the file migration is doing its thing.

It shouldn't break if the MigrateFIleTask is not at it's expected spot or if the extension points hasn't been implemented in the project's framework version.

(I've never done anything to fulltextsearch before, so don't assume I know what I'm doing, because I don't.)

# Parent issue
* https://github.com/silverstripe/silverstripe-framework/issues/8965