### PR TITLE
Make docs available without --prefer-source

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
 /tests export-ignore
-/docs export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore


### PR DESCRIPTION
Make docs available in composer require without preferring source to ensure vendor/bin/fulltextsearch_quickstart script has access to the files it needs and users have docs available available locally.