### PR TITLE
 Define getRunAsMemberID

### DIFF
--- a/src/Search/Processors/SearchUpdateCommitJobProcessor.php
+++ b/src/Search/Processors/SearchUpdateCommitJobProcessor.php
@@ -273,4 +273,9 @@ class SearchUpdateCommitJobProcessor implements QueuedJob
     {
         return $this->messages;
     }
+    
+    public function getRunAsMemberID()
+    {
+        return 0;
+    }
 }

--- a/src/Search/Processors/SearchUpdateQueuedJobProcessor.php
+++ b/src/Search/Processors/SearchUpdateQueuedJobProcessor.php
@@ -105,4 +105,9 @@ class SearchUpdateQueuedJobProcessor extends SearchUpdateBatchedProcessor implem
 
         return $result;
     }
+    
+    public function getRunAsMemberID()
+    {
+        return 0;
+    }
 }


### PR DESCRIPTION
On the latest v4.4 CWP pulling down the queued jobs looks like there needs to be an additional definition on each job.

https://github.com/symbiote/silverstripe-queuedjobs/commit/d6160257f74164864454d7766533e946a9d3b4c5