### PR TITLE
FIX Make remotepath optional to restore compatibility with CWP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,13 @@ env:
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL INSTALLER_VERSION=4.0.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.2.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.0
-      env: DB=PGSQL INSTALLER_VERSION=4.1.x-dev PHPUNIT_TEST=1
+      env: DB=PGSQL INSTALLER_VERSION=4.3.x-dev PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL INSTALLER_VERSION=4.1.x-dev PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL INSTALLER_VERSION=4.3.x-dev PHPUNIT_COVERAGE_TEST=1
     - php: 7.1
-      env: DB=MYSQL INSTALLER_VERSION=4.2.x-dev PHPUNIT_TEST=1 SUBSITES=1
+      env: DB=MYSQL INSTALLER_VERSION=4.4.x-dev PHPUNIT_TEST=1 SUBSITES=1
     - php: 7.2
       env: DB=MYSQL INSTALLER_VERSION=4.x-dev PHPUNIT_TEST=1
 
@@ -24,8 +24,8 @@ before_script:
 
   - composer validate
   - composer require --no-update symbiote/silverstripe-queuedjobs ^4.0
-  - if [[ $SUBSITES ]]; then composer require --no-update silverstripe/subsites 2.0.x-dev; fi
-  - if [[ $DB == "PGSQL" ]]; then composer require --no-update silverstripe/postgresql 2.0.x-dev; fi
+  - if [[ $SUBSITES ]]; then composer require --no-update silverstripe/subsites 2.3.x-dev; fi
+  - if [[ $DB == "PGSQL" ]]; then composer require --no-update silverstripe/postgresql 2.3.x-dev; fi
   - composer require --no-update silverstripe/installer "$INSTALLER_VERSION"
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 

--- a/src/Solr/Stores/SolrConfigStore_Post.php
+++ b/src/Solr/Stores/SolrConfigStore_Post.php
@@ -30,7 +30,10 @@ class SolrConfigStore_Post implements SolrConfigStore
             $options['host'] . ':' . $options['port'],
             $config['path']
         ]);
-        $this->remote = $config['remotepath'];
+
+        if (isset($config['remotepath'])) {
+            $this->remote = $config['remotepath'];
+        }
     }
 
     /**


### PR DESCRIPTION
During [the port of `CWPSolrConfigStore_Post` to this module](https://github.com/silverstripe/silverstripe-fulltextsearch/pull/246), the `remotepath` config was made mandatory by way of a dropped existence check. This made the store incompatible with CWP, where a `remotepath` is not set.

This PR reinstates the previous check, thereby fixing support for CWP and other environments like it.