### PR TITLE
NEW Bump minimum PHP to 7.1, SilverStripe to 3.7, replace PHP 7.2 incompatible code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,20 @@
 
 language: php
 
-sudo: false
+dist: trusty
 
 matrix:
   include:
-    - php: 5.4
-      env: DB=PGSQL CORE_RELEASE=3.1
-    - php: 5.5
-      env: DB=MYSQL CORE_RELEASE=3.2
-    - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.3 SUBSITES=1
-    - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.3 QUEUEDJOBS=1
-    - php: 7.1
-      env: DB=MYSQL CORE_RELEASE=3.6
-    - php: 7.1
-      env: DB=MYSQL CORE_RELEASE=3
+    - php: '7.1'
+      env: DB=PGSQL CORE_RELEASE=3.7
+    - php: '7.1'
+      env: DB=MYSQL CORE_RELEASE=3.7
+    - php: '7.2'
+      env: DB=MYSQL CORE_RELEASE=3.7 SUBSITES=1
+    - php: '7.2'
+      env: DB=MYSQL CORE_RELEASE=3.7 QUEUEDJOBS=1
+    - php: '7.3'
+      env: DB=MYSQL CORE_RELEASE=3.7
 
 before_script:
   - composer self-update || true
@@ -28,4 +26,4 @@ before_script:
   - cd ~/builds/ss
 
 script:
-  - vendor/bin/phpunit fulltextsearch/tests/
+  - vendor/bin/phpunit fulltextsearch/tests

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Compatible with PHP 7.2
 
 ## Requirements
 
-* SilverStripe 3.1+
+* SilverStripe 3.7+ (see previous 2.x releases for earlier SilverStripe 3 support, and 3.x for SilverStripe 4)
 * (optional) [silverstripe-phockito](https://github.com/hafriedlander/silverstripe-phockito) (for testing)
 
 ## Documentation

--- a/_config.php
+++ b/_config.php
@@ -1,9 +1,5 @@
 <?php
 
-// Ensure compatibility with PHP 7.2 ("object" is a reserved word),
-// with SilverStripe 3.6 (using Object) and SilverStripe 3.7 (using SS_Object)
-if (!class_exists('SS_Object')) class_alias('Object', 'SS_Object');
-
 global $databaseConfig;
 if (isset($databaseConfig['type'])) SearchUpdater::bind_manipulation_capture();
 

--- a/code/search/SearchIndex.php
+++ b/code/search/SearchIndex.php
@@ -471,12 +471,14 @@ abstract class SearchIndex extends ViewableData
      * Given an object and a field definition (as returned by fieldData) get the current value of that field on that object
      *
      * @param DataObject $object - The object to get the value from
-     * @param Array $field - The field definition to use
+     * @param array $field - The field definition to use
      * @return Mixed - The value of the field, or null if we couldn't look it up for some reason
      */
     protected function _getFieldValue($object, $field)
     {
-        set_error_handler(create_function('$no, $str', 'throw new Exception("HTML Parse Error: ".$str);'), E_ALL);
+        set_error_handler(function($no, $str) {
+            throw new Exception('HTML Parse Error: ' . $str);
+        }, E_ALL);
 
         try {
             foreach ($field['lookup_chain'] as $step) {

--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,15 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "~3.1",
+        "php": "^7.1",
+        "silverstripe/framework": "~3.7",
         "monolog/monolog": "~1.15"
     },
     "require-dev": {
-        "silverstripe/cms": "~3.1",
+        "silverstripe/cms": "~3.7",
         "hafriedlander/silverstripe-phockito": "*"
     },
-    "extra": {
-        "branch-alias": {
-            "2.x-dev": "2.5.x-dev"
-        }
-    },
+    "extra": [],
     "suggest": {
         "silverstripe/fulltextsearch-localsolr": "Adds a ready-to-use local Solr server for initial development"
     },


### PR DESCRIPTION
`create_function()` is deprecated, causing unit test failures in PHP 7.2