### PR TITLE
FIX: SearchUpdateQueuedJobProcessor JobType NULL

### DIFF
--- a/src/Search/Processors/SearchUpdateQueuedJobProcessor.php
+++ b/src/Search/Processors/SearchUpdateQueuedJobProcessor.php
@@ -40,7 +40,7 @@ class SearchUpdateQueuedJobProcessor extends SearchUpdateBatchedProcessor implem
 
     public function getJobType()
     {
-        return Config::inst()->get('SearchUpdateQueuedJobProcessor', 'reindex_queue');
+        return Config::inst()->get(SearchUpdateQueuedJobProcessor::class, 'reindex_queue');
     }
 
     public function jobFinished()

--- a/src/Search/Processors/SearchUpdateQueuedJobProcessor.php
+++ b/src/Search/Processors/SearchUpdateQueuedJobProcessor.php
@@ -40,7 +40,7 @@ class SearchUpdateQueuedJobProcessor extends SearchUpdateBatchedProcessor implem
 
     public function getJobType()
     {
-        return Config::inst()->get(SearchUpdateQueuedJobProcessor::class, 'reindex_queue');
+        return Config::inst()->get(__CLASS__, 'reindex_queue');
     }
 
     public function jobFinished()


### PR DESCRIPTION
getJobType method returns null as querying a string rather than a namespaced class.