### PR TITLE
FIX: allow update processor to be overridden by existing yml

### DIFF
--- a/src/Search/Updaters/SearchUpdater.php
+++ b/src/Search/Updaters/SearchUpdater.php
@@ -11,7 +11,8 @@ use SilverStripe\ORM\DB;
 use SilverStripe\FullTextSearch\Search\FullTextSearch;
 use SilverStripe\FullTextSearch\Search\SearchIntrospection;
 use SilverStripe\FullTextSearch\Search\Variants\SearchVariant;
-use SilverStripe\FullTextSearch\Search\Processors\SearchUpdateImmediateProcessor;
+use SilverStripe\FullTextSearch\Search\Processors\SearchUpdateProcessor;
+
 use ReflectionClass;
 
 /**
@@ -151,7 +152,7 @@ class SearchUpdater
                     foreach ($dirtyids as $dirtyclass => $ids) {
                         if ($ids) {
                             if (!self::$processor) {
-                                self::$processor = Injector::inst()->create(SearchUpdateImmediateProcessor::class);
+                                self::$processor = Injector::inst()->create(SearchUpdateProcessor::class);
                             }
                             self::$processor->addDirtyIDs($dirtyclass, $ids, $index);
                         }


### PR DESCRIPTION
One of the 3->4 update commits (6066af5841fd1df21ef32ff3fa089c6e48ea4f26) replaced `SearchUpdateProcessor` with `SearchUpdateImmediateProcessor`, but that means that the existing processor yml fails to replace the `SearchUpdateImmediateProcessor` with `SearchUpdateQueuedJobProcessor`  as I think is intended?

c.f https://github.com/silverstripe/silverstripe-fulltextsearch/blob/3/_config/processor.yml#L19