### PR TITLE
WIP: NEW Respect canView permissions during index operations

### DIFF
--- a/src/Search/Services/IndexableService.php
+++ b/src/Search/Services/IndexableService.php
@@ -4,27 +4,40 @@ namespace SilverStripe\FullTextSearch\Search\Services;
 
 use SilverStripe\Core\Extensible;
 use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\FullTextSearch\Search\FullTextSearch;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\Tests\MySQLDatabaseTest\Data;
+use SilverStripe\Security\Member;
 
 /**
- * Checks if a DataObject is publically viewable thus able to be added or retrieved from a publically searchable index
- * Caching results because these checks may be done multiple times as there a few different code paths that search
- * results might follow in real-world search implementations
+ * Checks if a DataObject is publicly viewable, thus able to be added to or retrieved from a publicly searchable index.
+ * Results are cached because these checks may be run multiple times, as there a few different code paths that search
+ * results might follow in real-world search implementations.
  */
 class IndexableService
 {
-
     use Injectable;
     use Extensible;
 
     protected $cache = [];
 
+    /**
+     * Clears the internal indexable cache
+     */
     public function clearCache(): void
     {
         $this->cache = [];
     }
 
+    /**
+     * Checks and caches whether the given DataObject can be indexed. This is determined by two factors:
+     *
+     * - Whether the ShowInSearch property / getShowInSearch method evaluates to true
+     * - Whether the canView method evaluates to true against an anonymous user (optional, can be disabled)
+     *
+     * @see FullTextSearch::isCanViewCheckDisabledForClass()
+     * @param DataObject $obj
+     * @return bool
+     */
     public function isIndexable(DataObject $obj): bool
     {
         // check if is a valid DataObject that has been persisted to the database
@@ -44,11 +57,31 @@ class IndexableService
             $value = false;
         }
 
+        // Run canView check as anonymous user if it hasn't been disabled for this DataObject
+        $objClass = $obj->getClassName();
+        if (!FullTextSearch::isCanViewCheckDisabledForClass($objClass)) {
+            $value = $value && Member::actAs(null, function () use ($obj, $objClass) {
+                // Attempt to use optimised permission checker if present.
+                // NOTE: This reduces the scope of the check to DB-based permissions (custom canView logic is ignored)
+                if (method_exists($objClass, 'getPermissionChecker')) {
+                    return $objClass::singleton()->getPermissionChecker()->canView($obj->ID);
+                }
+
+                return $obj->canView();
+            });
+        }
+
         $this->extend('updateIsIndexable', $obj, $value);
         $this->cache[$key] = $value;
         return $value;
     }
 
+    /**
+     * Generates a unique key to cache each DataObject with. Can be extended via updateCacheKey.
+     *
+     * @param DataObject $obj
+     * @return string
+     */
     protected function getCacheKey(DataObject $obj): string
     {
         $key = $obj->ClassName . '_' . $obj->ID;

--- a/tests/SolrIndexTest.php
+++ b/tests/SolrIndexTest.php
@@ -416,6 +416,13 @@ class SolrIndexTest extends SapphireTest
             ->setMethods(['addDocument', 'deleteById'])
             ->getMock();
 
+        // We only want to test the ShowInSearch part of IndexableService, so we disable the canView check
+        Config::modify()->set(
+            FullTextSearch::class,
+            'disable_preindex_canview_check',
+            [DataObject::class]
+        );
+
         $index = new SolrIndexTest_ShowInSearchIndex();
         $index->setService($serviceMock);
         FullTextSearch::force_index_list($index);


### PR DESCRIPTION
The module now calls `canView()` on documents to determine whether they should exist in the index at all, no longer solely relying on this check occurring post-search. This decreases the likelihood of data leakage, and should result in more accurate search result pagination.

This new logic attempts to make use of `InheritedPermissions::canViewMultiple()` when the DataObject exposes it via `getPermissionChecker()`. This results in less accurate output, as it's based solely on permissions stored in the database, but should be sufficient for most models that are using it.

The new check can be disabled on a per-class basis (will also disable descendants), for situations where it's too expensive or known not to be necessary.

This PR also bumps the minimum PHP requirement for this module to 7.1, to enable use of modern language features.

#### Performance testing

Initial benchmarks (native PHP 7.1 / MySQL 8 on a mid-range 15" 2018 MacBook Pro, running against data from the default frameworktest population script, which generates ~2000 Page objects):

```
canView Disabled
12.10s user 5.63s system 79% cpu 22.353 total
12.15s user 5.64s system 77% cpu 22.970 total
12.21s user 5.66s system 73% cpu 24.229 total

canView Enabled (with canViewMultiple cache)
12.19s user 5.48s system 80% cpu 22.063 total
12.34s user 5.66s system 80% cpu 22.382 total
12.51s user 5.62s system 71% cpu 25.334 total

canView Enabled (without canViewMultiple cache)
21.97s user 6.22s system 79% cpu 35.486 total
22.06s user 6.49s system 79% cpu 35.965 total
22.74s user 7.01s system 77% cpu 38.396 total
```

#### TODO

- [ ] Add `$preindex` condition to `IndexableService::isIndexable()` method, and have the `FullTextSearch::isCanViewCheckDisabledForClass()` check apply only when this is `true`
- [ ] Consider additional `areIndexable(DataList $objs)` method to shift the `InheritedPermissions` cache warming into `IndexableService`
- [ ] Documentation
- [ ] Unit tests
- [ ] Ensure benchmarks still hold up, as implementation has changed since original tests