### PR TITLE
DOC Use the correct name for the executable in the getting started doc

### DIFF
--- a/docs/en/01_getting_started.md
+++ b/docs/en/01_getting_started.md
@@ -39,7 +39,7 @@ configured and running) that each connector deals with itself, in a way best sui
 If you are running on a Linux-based system, you can get up and running quickly with the quickstart script, like so:
 
 ```bash
-composer require silverstripe/fulltextsearch --prefer-source && vendor/bin/fts_quickstart
+composer require silverstripe/fulltextsearch --prefer-source && vendor/bin/fulltextsearch_quickstart
 ```
 
 This will:


### PR DESCRIPTION
Minor tweak to the doc to use the correct executable name in the getting started doc.