### PR TITLE
FIX: Index fields for subclasses

### DIFF
--- a/src/Search/Indexes/SearchIndex.php
+++ b/src/Search/Indexes/SearchIndex.php
@@ -204,7 +204,7 @@ abstract class SearchIndex extends ViewableData
                 $type = null;
                 $fieldoptions = $options;
 
-                $fields = DataObject::getSchema()->databaseFields($class);
+                $fields = DataObject::getSchema()->databaseFields($dataclass);
 
                 if (isset($fields[$field])) {
                     $type = $fields[$field];


### PR DESCRIPTION
The superclass was being checked for the field in each cycle of the loop, prohibiting the indexing of data fields from subclasses.