### PR TITLE
FIX Only use values that are not empty

### DIFF
--- a/src/Solr/Stores/SolrConfigStore_File.php
+++ b/src/Solr/Stores/SolrConfigStore_File.php
@@ -13,7 +13,7 @@ class SolrConfigStore_File implements SolrConfigStore
     public function __construct($config)
     {
         $this->local = $config['path'];
-        $this->remote = isset($config['remotepath']) ? $config['remotepath'] : $config['path'];
+        $this->remote = !empty($config['remotepath']) ? $config['remotepath'] : $config['path'];
     }
 
     public function getTargetDir($index)

--- a/src/Solr/Stores/SolrConfigStore_Post.php
+++ b/src/Solr/Stores/SolrConfigStore_Post.php
@@ -26,12 +26,12 @@ class SolrConfigStore_Post implements SolrConfigStore
 
         $this->url = implode('', [
             'http://',
-            isset($config['auth']) ? $config['auth'] . '@' : '',
+            !empty($config['auth']) ? $config['auth'] . '@' : '',
             $options['host'] . ':' . $options['port'],
             $config['path']
         ]);
 
-        if (isset($config['remotepath'])) {
+        if (!empty($config['remotepath'])) {
             $this->remote = $config['remotepath'];
         }
     }

--- a/src/Solr/Stores/SolrConfigStore_WebDAV.php
+++ b/src/Solr/Stores/SolrConfigStore_WebDAV.php
@@ -18,11 +18,14 @@ class SolrConfigStore_WebDAV implements SolrConfigStore
 
         $this->url = implode('', array(
             'http://',
-            isset($config['auth']) ? $config['auth'] . '@' : '',
-            $options['host'] . ':' . (isset($config['port']) ? $config['port'] : $options['port']),
+            !empty($config['auth']) ? $config['auth'] . '@' : '',
+            $options['host'] . ':' . (!empty($config['port']) ? $config['port'] : $options['port']),
             $config['path']
         ));
-        $this->remote = $config['remotepath'];
+
+        if (!empty($config['remotepath'])) {
+            $this->remote = $config['remotepath'];
+        }
     }
 
     public function getTargetDir($index)


### PR DESCRIPTION
Previously the `isset` check would still allow falsey values.

Fix for #260. It's quite possible the module won't get too much longterm love going forward but this could be seen as maintenance to allow for configurations where these settings are set to null but still incorrectly applied.