### PR TITLE
Make SearchQuery_Range injectable.

### DIFF
--- a/src/Search/Queries/SearchQuery_Range.php
+++ b/src/Search/Queries/SearchQuery_Range.php
@@ -2,6 +2,7 @@
 
 namespace SilverStripe\FullTextSearch\Search\Queries;
 
+use SilverStripe\Core\Injector\Injectable;
 use SilverStripe\Dev\Deprecation;
 
 /**
@@ -10,6 +11,8 @@ use SilverStripe\Dev\Deprecation;
  */
 class SearchQuery_Range
 {
+    use Injectable;
+    
     public $start = null;
     public $end = null;
 


### PR DESCRIPTION
[The docs](https://github.com/silverstripe/silverstripe-fulltextsearch/blob/3/docs/en/04_querying.md#searching-value-ranges) indicate that this class should be injectable.