### PR TITLE
ENH Show error message instead of error code on WebDAV check

### DIFF
--- a/src/Utils/WebDAV.php
+++ b/src/Utils/WebDAV.php
@@ -33,7 +33,9 @@ class WebDAV
             return true;
         }
 
-        user_error("Got error from webdav server - " . $code, E_USER_ERROR);
+        $err = curl_error($ch);
+
+        user_error("Got error from webdav server - " . $err, E_USER_ERROR);
     }
 
     public static function mkdir($url)


### PR DESCRIPTION
Without this change, the error message isn't that helpful
`Got error from webdav server - 0`

With this change, the error message is more suggestive:
`Got error from webdav server - Failed to connect to cc4f1a92edc7f330 port 80: Connection refused`