### PR TITLE
Close curl handles after use

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     ],
     "require": {
         "php": ">=7.1",
+        "ext-curl": "*",
         "silverstripe/framework": "^4.0",
         "monolog/monolog": "~1.15",
         "ptcinc/solr-php-client": "^1.0",

--- a/src/Utils/WebDAV.php
+++ b/src/Utils/WebDAV.php
@@ -22,9 +22,13 @@ class WebDAV
         }
 
         $ch = self::curl_init($url, 'PROPFIND');
-        
-        $res = curl_exec($ch);
+
+        curl_exec($ch);
         $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        $err = curl_error($ch);
+
+        curl_close($ch);
 
         if ($code == 404) {
             return false;
@@ -33,8 +37,6 @@ class WebDAV
             return true;
         }
 
-        $err = curl_error($ch);
-
         user_error("Got error from webdav server - " . $err, E_USER_ERROR);
     }
 
@@ -42,8 +44,9 @@ class WebDAV
     {
         $ch = self::curl_init(rtrim($url, '/') . '/', 'MKCOL');
 
-        $res = curl_exec($ch);
+        curl_exec($ch);
         $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
 
         return $code == 201;
     }
@@ -58,10 +61,12 @@ class WebDAV
 
         curl_setopt($ch, CURLOPT_INFILE, $handle);
 
-        $res = curl_exec($ch);
+        curl_exec($ch);
         fclose($handle);
+        $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
 
-        return curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        return $code;
     }
 
     public static function upload_from_string($string, $url)


### PR DESCRIPTION
I noticed that the curl handles are not closed after use, which means (in older versions of PHP) that the resources are not released potentially leading to memory leaks.

Changes:

 - Add `ext-curl` dep to compsoer file
 - remove unsued variable declarations
 - closed curl handles after use