### PR TITLE
FIX Don't assume DataObject::canView always returns bool

### DIFF
--- a/src/Search/Services/SearchableService.php
+++ b/src/Search/Services/SearchableService.php
@@ -151,12 +151,12 @@ class SearchableService
                 // Anonymous member canView() for indexing
                 if (!$this->classSkipsCanViewCheck($objClass)) {
                     $value = Member::actAs(null, function () use ($obj) {
-                        return $obj->canView();
+                        return (bool) $obj->canView();
                     });
                 }
             } else {
                 // Current member canView() check for retrieving search results
-                $value = $obj->canView();
+                $value = (bool) $obj->canView();
             }
         }
         $this->extend('updateIsSearchable', $obj, $indexing, $value);


### PR DESCRIPTION
Fixes #304 
See also silverstripe/silverstripe-elemental#951

Because there is no return value typehinting in DataObject::canView, the value returned from that method can be of any type. We must cast to boolean before returning the value to avoid possible errors with non-boolean return types.