### PR TITLE
Symfony process constructor fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "silverstripe/framework": "^4.10",
         "monolog/monolog": "~1.15",
         "ptcinc/solr-php-client": "^1.0",
-        "symfony/process": "^3.2 || ^4",
+        "symfony/process": "^3.4 || ^4",
         "tractorcow/silverstripe-proxy-db": "~0.1",
         "ext-curl": "*"
     },

--- a/src/Solr/Reindex/Handlers/SolrReindexImmediateHandler.php
+++ b/src/Solr/Reindex/Handlers/SolrReindexImmediateHandler.php
@@ -77,15 +77,12 @@ class SolrReindexImmediateHandler extends SolrReindexBase
         $indexClass = get_class($indexInstance);
 
         // Build script parameters
-        $indexClassEscaped = $indexClass;
         $statevar = json_encode($state);
 
         if (strpos(PHP_OS, "WIN") !== false) {
             $statevar = '"' . str_replace('"', '\\"', $statevar) . '"';
         } else {
             $statevar = "'" . $statevar . "'";
-            $class = addslashes($class);
-            $indexClassEscaped = addslashes($indexClass);
         }
 
         $php = Environment::getEnv('SS_PHP_BIN') ?: Config::inst()->get(static::class, 'php_bin');
@@ -93,11 +90,12 @@ class SolrReindexImmediateHandler extends SolrReindexBase
         // Build script line
         $frameworkPath = ModuleLoader::getModule('silverstripe/framework')->getPath();
         $scriptPath = sprintf("%s%scli-script.php", $frameworkPath, DIRECTORY_SEPARATOR);
-        $scriptTask = "{$php} {$scriptPath} dev/tasks/{$taskName}";
 
         $cmd = [
-            $scriptTask,
-            "index={$indexClassEscaped}",
+            $php,
+            $scriptPath,
+            "dev/tasks/{$taskName}",
+            "index={$indexClass}",
             "class={$class}",
             "group={$group}",
             "groups={$groups}",


### PR DESCRIPTION
This pull  requests bumps the symfony/process minimum version from 3.2 to 3.4 which allows the commandline param to be a array or a string.
Also implements fixes from @GuySartorelli 