### PR TITLE
Don't double-escape state field

### DIFF
--- a/src/Solr/Reindex/Handlers/SolrReindexImmediateHandler.php
+++ b/src/Solr/Reindex/Handlers/SolrReindexImmediateHandler.php
@@ -77,12 +77,6 @@ class SolrReindexImmediateHandler extends SolrReindexBase
         $indexClass = get_class($indexInstance);
         $statevar = json_encode($state);
 
-        if (strpos(PHP_OS, "WIN") !== false) {
-            $statevar = '"' . str_replace('"', '\\"', $statevar) . '"';
-        } else {
-            $statevar = "'" . $statevar . "'";
-        }
-
         $php = Environment::getEnv('SS_PHP_BIN') ?: Config::inst()->get(static::class, 'php_bin');
 
         // Build script line


### PR DESCRIPTION
Symfony now escapes each component separately.
See https://github.com/silverstripe/silverstripe-fulltextsearch/issues/311