### PR TITLE
FIX Ensure DB is active before processing

### DIFF
--- a/src/Search/Processors/SearchUpdateProcessor.php
+++ b/src/Search/Processors/SearchUpdateProcessor.php
@@ -5,6 +5,7 @@ namespace SilverStripe\FullTextSearch\Search\Processors;
 use SilverStripe\FullTextSearch\Search\Services\SearchableService;
 use SilverStripe\FullTextSearch\Search\Variants\SearchVariantVersioned;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DB;
 use SilverStripe\FullTextSearch\Search\Variants\SearchVariant;
 use SilverStripe\FullTextSearch\Search\FullTextSearch;
 use SilverStripe\Versioned\Versioned;
@@ -154,6 +155,9 @@ abstract class SearchUpdateProcessor
      */
     public function process()
     {
+        if (!DB::is_active()) {
+            return false;
+        }
         // Generate and commit all instances
         $indexes = $this->prepareIndexes();
         foreach ($indexes as $index) {


### PR DESCRIPTION
When using the TestSession with behat on a project while silverstripe-fulltextsearch is installed, the following chain of events happens

- Temporary database used by TestSession is destroyed
- PHP shuts down
- The following is run, which was defined in FullTextSearch - SearchUpdater.php
- `register_shutdown_function(array(SearchUpdater::class, "flush_dirty_indexes"));`
- `flush_dirty_indexes` will eventually call `SearchUpdateProcessor::process()` - which will do a bunch of DB queries
- however there's no database, which triggers `No database selected` errors
