### PR TITLE
DEP Require proxy-db ^1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "monolog/monolog": "~1.15",
         "silverstripe/solr-php-client": "^1.0",
         "symfony/process": "^3.4 || ^4",
-        "tractorcow/silverstripe-proxy-db": "~0.1",
+        "tractorcow/silverstripe-proxy-db": "^1",
         "ext-curl": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Was originally added [here](https://github.com/silverstripe/silverstripe-fulltextsearch/pull/322) which went into 3.10.1

Looks like this was accidentally reverted on merge-up https://github.com/silverstripe/silverstripe-fulltextsearch/compare/3.10.1...3.11.0

Tag 3.11.1 on merge