### PR TITLE
MNT Fix unit test

### DIFF
--- a/tests/BatchedProcessorTest.php
+++ b/tests/BatchedProcessorTest.php
@@ -106,7 +106,7 @@ class BatchedProcessorTest extends SapphireTest
             $processor->addDirtyIDs(
                 BatchedProcessorTest_Object::class,
                 array(array(
-                    'id' => $id,
+                    'id' => $object->ID,
                     'state' => array(SearchVariantVersioned::class => 'Stage')
                 )),
                 BatchedProcessorTest_Index::class


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/37

Might fix https://github.com/silverstripe/recipe-solr-search/runs/7459144288?check_suite_focus=true#step:12:69
`1) SilverStripe\FullTextSearch\Tests\BatchedProcessorTest::testBatching
Failed asserting that 15 matches expected 9.`

Don't need to release, though ensure is merged all the way up as recipe-solr-search uses x-dev branches